### PR TITLE
Update the split string with a regex that handles both nodesecurity.io and npmjs.com

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ let program = require('commander');
 let { exec } = require('child_process');
 
 const AUDIT_COMMAND = 'npm audit';
-const SPLIT_STRING = 'https://nodesecurity.io/advisories/';
+const SPLIT_REGEX = /(https:\/\/(nodesecurity.io|npmjs.com)\/advisories\/)/;
 
 let exceptionIds = [];
 
@@ -29,7 +29,7 @@ program
 
     // stdout
     audit.stdout.on('data', data => {
-      const ids = data.split(SPLIT_STRING).map(str => str.substring(0, 4).trim());
+      const ids = data.split(SPLIT_REGEX).map(str => str.substring(0, 4).trim());
 
       const numberIds = ids.map(id => {
         if (isNaN(parseInt(id, 10))) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-handler",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-npm-audit",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "Jee Mok <jee.ict@hotmail.com>",
   "description": "Better npm audit",
   "license": "MIT",


### PR DESCRIPTION
With npm 6.6.0, the default address is https://npmjs.com/advisories/ rather than nodesecurity.io. This PR updates the Split check to look for that URL as well as the original