### PR TITLE
Add option for global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@ Made to allow skipping certain vulnerabilities, and any extra handling that are 
 
 ## Installation
 
-    $ npm install better-npm-audit --save
+    $ npm install better-npm-audit
 
+or
 
-## Package.json
+    $ npm install -g better-npm-audit
+
+## Useage
+    
+### Package.json
 
 ```JSON
 {
@@ -22,6 +27,11 @@ Made to allow skipping certain vulnerabilities, and any extra handling that are 
   }
 }
 ```
+
+### Run Global
+
+`better-npm-audit audit`
+
 
 ## Flags
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "main": "index.js",
   "bin": {
-    "better-audit": "./index.js"
+    "better-npm-audit": "./index.js"
   },
   "dependencies": {
     "commander": "^2.19.0"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "ci"
   ],
   "main": "index.js",
+  "bin": {
+    "better-audit": "./index.js"
+  },
   "dependencies": {
     "commander": "^2.19.0"
   },


### PR DESCRIPTION
- Added `bin` key in package.json to enable running `better-npm-audit` globally.
- Updated README.md to reflect changes.
- `--save` isn't required as it's saved to package.json by default.