### PR TITLE
feature: warning when exceptionIds are unused.

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ node_modules/yargs-unparser/node_modules/yargs-parser
 
 - [@EdwinTaylor](https://github.com/alertme-edwin) for all the bug reports and improvement suggestions.
 
+- [@MrHus](https://github.com/MrHus) for the logging of unused exceptions from the .nsprc file and -ignore flags. Courtesy of 42 BV.
+
 <br />
 
 ---

--- a/utils/common.js
+++ b/utils/common.js
@@ -29,7 +29,7 @@ function mapLevelToNumber(auditLevel) {
  * @param  {Array} exceptionIds     List of exception vulnerabilities
  * @return {Array}                  Returns the list of found vulnerabilities
  */
-function getVulnerabilities(jsonBuffer = '', auditLevel = 0, exceptionIds = []) {
+function getRawVulnerabilities(jsonBuffer = '', auditLevel = 0) {
   // NPM v6 uses `advisories`
   // NPM v7 uses `vulnerabilities`
   // Refer to the test folder for some sample mockups
@@ -39,8 +39,7 @@ function getVulnerabilities(jsonBuffer = '', auditLevel = 0, exceptionIds = []) 
   if (advisories) {
     return Object.values(advisories)
         .filter(advisory => mapLevelToNumber(advisory.severity) >= auditLevel) // Filter out if there is requested audit level
-        .map(advisory => advisory.id) // Map out the vulnerabilities IDs
-        .filter(id => !exceptionIds.includes(id)); // Filter out exceptions provided by user
+        .map(advisory => advisory.id); // Map out the vulnerabilities IDs
   }
 
   // NPM v7 handling
@@ -53,11 +52,20 @@ function getVulnerabilities(jsonBuffer = '', auditLevel = 0, exceptionIds = []) 
           const cleanedArray = get(vulnerability, 'via', []).map(each => get(each, 'source')).filter(Boolean);
           // Compile into a single array
           return acc.concat(cleanedArray);
-        }, [])
-        .filter(id => !exceptionIds.includes(id)); // Filter out exceptions provided by user
+        }, []);
   }
 
   return [];
+}
+
+/**
+ * Takes the rawVulnerabilities and filters out the exceptionIds
+ * @param  {Array} rawVulnerabilities  List of raw vulnerabilities to filter
+ * @param  {Array} exceptionIds     List of exception vulnerabilities
+ * @return {Array}                  Returns the list of found vulnerabilities
+ */
+function filterExceptions(rawVulnerabilities, exceptionIds = []) {
+  return rawVulnerabilities.filter(id => !exceptionIds.includes(id));
 }
 
 /**
@@ -126,5 +134,6 @@ module.exports = {
   isWholeNumber,
   isJsonString,
   mapLevelToNumber,
-  getVulnerabilities,
+  getRawVulnerabilities,
+  filterExceptions,
 };


### PR DESCRIPTION
When the list of exceptions in the .nsprc file grows it is nice that we
show that exceptions are no longer needed. This way developers have
an easy time pruning the exceptions.

By comparing the exceptionIds with the actual found vulnerabilities
we can check if the exceptionIds were actually used or not. Then we
can show an info message, containing all exceptionIds which are not
used.

Had to split up the common `getVulnerabilities` into two functions:
`getRawVulnerabilities` and `filterExceptions`.

The `getRawVulnerabilities` now simply returns the vulnerabilities as
reported by `npm audit` normalized, but without the exceptionIds
excluded. This way we can calculate the unusedExceptionIds

Had to pass along the unusedExceptionIds's from the `audit` function to the
`auditLog` function, and then finally to the `handleFinish` function
so it can be logged there.

Also fixed some spelling mistakes.