### PR TITLE
Log exception when parsing .nsprc fails.

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -20,6 +20,7 @@ export function isJsonString(string: string): boolean {
   try {
     JSON.parse(string);
   } catch (e) {
+    console.log('Failed parsing .nsprc file: ' + e)
     return false;
   }
   return true;


### PR DESCRIPTION
This PR adds console logging, when an error occurs parsing .nsprc file content to JSON.

Background:
I've struggled to find the reason, why .nsprc file is not being used, despite the fact, it was provided. It turned out, that there was an error parsing .nsprc to JSON, because I'd included an URL in the description. With a logging it would be clear at first run.