### PR TITLE
add module-ignore flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ npm run audit
 
 | Flag           | Short | Description                                                                    |
 | -------------- | ----- | ------------------------------------------------------------------------------ |
-| `--exclude`    | `-x`  | Exceptions or the vulnerabilities ID(s) to exclude                             |
+| `--exclude`    | `-x`  | Exceptions or the vulnerabilities ID(s) to exclude
+| `--module-ignore` | `-m` | Names of modules to exclude                            |
 | `--level`      | `-l`  | The minimum audit level to validate; Same as the original `--audit-level` flag |
 | `--production` | `-p`  | Skip checking the `devDependencies`                                            |
 | `--registry`   | `-r`  | The npm registry url to use                                                    |

--- a/index.ts
+++ b/index.ts
@@ -18,8 +18,9 @@ const program = new Command();
  * @param  {String} auditCommand    The NPM audit command to use (with flags)
  * @param  {String} auditLevel      The level of vulnerabilities we care about
  * @param  {Array}  exceptionIds    List of vulnerability IDs to exclude
+ * @param  {Array} modulesToIgnore   List of vulnerable modules to ignore in audit results
  */
-export function callback(auditCommand: string, auditLevel: AuditLevel, exceptionIds: number[]): void {
+export function callback(auditCommand: string, auditLevel: AuditLevel, exceptionIds: number[], modulesToIgnore: string[]): void {
   // Increase the default max buffer size (1 MB)
   const audit = exec(`${auditCommand} --json`, { maxBuffer: MAX_BUFFER_SIZE });
 
@@ -32,7 +33,7 @@ export function callback(auditCommand: string, auditLevel: AuditLevel, exception
 
   // Once the stdout has completed, process the output
   if (audit.stderr) {
-    audit.stderr.on('close', () => handleFinish(jsonBuffer, auditLevel, exceptionIds));
+    audit.stderr.on('close', () => handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore));
     // stderr
     audit.stderr.on('data', console.error);
   }
@@ -44,6 +45,7 @@ program
   .command('audit')
   .description('execute npm audit')
   .option('-x, --exclude <ids>', 'Exceptions or the vulnerabilities ID(s) to exclude.')
+  .option('-m, --module-ignore <moduleNames>', 'Names of modules to ignore.')
   .option('-l, --level <auditLevel>', 'The minimum audit level to validate.')
   .option('-p, --production', 'Skip checking the devDependencies.')
   .option('-r, --registry <url>', 'The npm registry url to use.')

--- a/src/handlers/handleFinish.ts
+++ b/src/handlers/handleFinish.ts
@@ -7,10 +7,11 @@ import { processAuditJson } from '../utils/vulnerability';
  * @param  {String} jsonBuffer    NPM audit stringified JSON payload
  * @param  {Number} auditLevel    The level of vulnerabilities we care about
  * @param  {Array} exceptionIds   List of vulnerability IDs to exclude
+ * @param  {Array} modulesToIgnore   List of vulnerable modules to ignore in audit results
  * @return {undefined}
  */
-export default function handleFinish(jsonBuffer: string, auditLevel: AuditLevel, exceptionIds: number[]): void {
-  const { unhandledIds, vulnerabilityIds, report, failed } = processAuditJson(jsonBuffer, auditLevel, exceptionIds);
+export default function handleFinish(jsonBuffer: string, auditLevel: AuditLevel, exceptionIds: number[], modulesToIgnore: string[]): void {
+  const { unhandledIds, vulnerabilityIds, report, failed } = processAuditJson(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
 
   // If unable to process the audit JSON
   if (failed) {

--- a/src/handlers/handleInput.ts
+++ b/src/handlers/handleInput.ts
@@ -9,7 +9,7 @@ import { getExceptionsIds } from '../utils/vulnerability';
  * @param  {Object} options     User's command options or flags
  * @param  {Function} fn        The function to handle the inputs
  */
-export default function handleInput(options: CommandOptions, fn: (T1: string, T2: AuditLevel, T3: number[]) => void): void {
+export default function handleInput(options: CommandOptions, fn: (T1: string, T2: AuditLevel, T3: number[], T4: string[]) => void): void {
   // Generate NPM Audit command
   const auditCommand: string = [
     'npm audit',
@@ -28,6 +28,7 @@ export default function handleInput(options: CommandOptions, fn: (T1: string, T2
   const nsprc = readFile('.nsprc');
   const cmdExceptions: number[] = get(options, 'exclude', '').split(',').filter(isWholeNumber).map(Number);
   const exceptionIds: number[] = getExceptionsIds(nsprc, cmdExceptions);
+  const cmdModuleIgnore: string[] = get(options, 'moduleIgnore', '').split(',');
 
-  fn(auditCommand, auditLevel, exceptionIds);
+  fn(auditCommand, auditLevel, exceptionIds, cmdModuleIgnore);
 }

--- a/src/types/general.d.ts
+++ b/src/types/general.d.ts
@@ -2,6 +2,7 @@ import { AuditLevel, Severity } from './level';
 
 export interface CommandOptions {
   readonly exclude?: string;
+  readonly moduleIgnore?: string;
   readonly production?: boolean;
   readonly level?: AuditLevel;
   readonly registry?: string;

--- a/src/types/general.d.ts
+++ b/src/types/general.d.ts
@@ -53,6 +53,7 @@ export interface v7VulnerabilityVia {
 export interface ProcessedResult {
   readonly unhandledIds: number[];
   readonly vulnerabilityIds: number[];
+  readonly vulnerabilityModules: string[];
   readonly report: string[][];
   readonly failed?: boolean;
 }

--- a/src/utils/vulnerability.ts
+++ b/src/utils/vulnerability.ts
@@ -60,6 +60,7 @@ export function processAuditJson(
     return {
       unhandledIds: [],
       vulnerabilityIds: [],
+      vulnerabilityModules: [],
       report: [],
       failed: true,
     };
@@ -96,6 +97,9 @@ export function processAuditJson(
         ]);
 
         acc.vulnerabilityIds.push(Number(cur.id));
+        if (!acc.vulnerabilityModules.includes(cur.module_name)) {
+          acc.vulnerabilityModules.push(cur.module_name);
+        }
 
         // Found unhandled vulnerabilities
         if (shouldAudit && !isExcepted && !isIgnoredModule) {
@@ -107,6 +111,7 @@ export function processAuditJson(
       {
         unhandledIds: [],
         vulnerabilityIds: [],
+        vulnerabilityModules: [],
         report: [],
       },
     );
@@ -146,6 +151,9 @@ export function processAuditJson(
           ]);
 
           acc.vulnerabilityIds.push(id);
+          if (!acc.vulnerabilityModules.includes(moduleName)) {
+            acc.vulnerabilityModules.push(moduleName);
+          }
 
           // Found unhandled vulnerabilities
           if (shouldAudit && !isExcepted && !isIgnoredModule) {
@@ -158,6 +166,7 @@ export function processAuditJson(
       {
         unhandledIds: [],
         vulnerabilityIds: [],
+        vulnerabilityModules: [],
         report: [],
       },
     );
@@ -165,6 +174,7 @@ export function processAuditJson(
   return {
     unhandledIds: [],
     vulnerabilityIds: [],
+    vulnerabilityModules: [],
     report: [],
     failed: true,
   };

--- a/src/utils/vulnerability.ts
+++ b/src/utils/vulnerability.ts
@@ -47,9 +47,15 @@ export function mapLevelToNumber(auditLevel: AuditLevel | string): AuditNumber {
  * @param  {String} jsonBuffer      NPM Audit JSON string buffer
  * @param  {String} auditLevel      User's target audit level
  * @param  {Array}  exceptionIds    User's exception IDs
+ * @param  {Array} modulesToIgnore  Users modules to ignore
  * @return {Object}                 Processed vulnerabilities details
  */
-export function processAuditJson(jsonBuffer = '', auditLevel: AuditLevel = 'info', exceptionIds: number[] = []): ProcessedResult {
+export function processAuditJson(
+  jsonBuffer = '',
+  auditLevel: AuditLevel = 'info',
+  exceptionIds: number[] = [],
+  modulesToIgnore: string[] = [],
+): ProcessedResult {
   if (!isJsonString(jsonBuffer)) {
     return {
       unhandledIds: [],
@@ -68,30 +74,31 @@ export function processAuditJson(jsonBuffer = '', auditLevel: AuditLevel = 'info
   if (advisories) {
     return Object.values(advisories).reduce(
       (acc: ProcessedResult, cur: v6Advisory) => {
-        const shouldAudit: boolean = mapLevelToNumber(cur.severity) >= mapLevelToNumber(auditLevel);
-        const isExcepted: boolean = exceptionIds.includes(Number(cur.id));
+        const shouldAudit = mapLevelToNumber(cur.severity) >= mapLevelToNumber(auditLevel);
+        const isExcepted = exceptionIds.includes(Number(cur.id));
+        const isIgnoredModule = modulesToIgnore.includes(cur.module_name);
 
         // Record this vulnerability into the report, and highlight it using yellow color if it's new
         acc.report.push([
-          color(cur.id, isExcepted ? '' : 'yellow'),
-          color(cur.module_name, isExcepted ? '' : 'yellow'),
-          color(cur.title, isExcepted ? '' : 'yellow'),
+          color(cur.id, isExcepted || isIgnoredModule ? '' : 'yellow'),
+          color(cur.module_name, isExcepted || isIgnoredModule ? '' : 'yellow'),
+          color(cur.title, isExcepted || isIgnoredModule ? '' : 'yellow'),
           color(
             trimArray(
               cur.findings.reduce((a, c) => [...a, ...c.paths] as [], []),
               MAX_PATHS_SIZE,
             ).join('\n'),
-            isExcepted ? '' : 'yellow',
+            isExcepted || isIgnoredModule ? '' : 'yellow',
           ),
-          color(cur.severity, isExcepted ? '' : 'yellow', getSeverityBgColor(cur.severity)),
-          color(cur.url, isExcepted ? '' : 'yellow'),
-          isExcepted ? 'y' : color('n', 'yellow'),
+          color(cur.severity, isExcepted || isIgnoredModule ? '' : 'yellow', getSeverityBgColor(cur.severity)),
+          color(cur.url, isExcepted || isIgnoredModule ? '' : 'yellow'),
+          isExcepted || isIgnoredModule ? 'y' : color('n', 'yellow'),
         ]);
 
         acc.vulnerabilityIds.push(Number(cur.id));
 
         // Found unhandled vulnerabilities
-        if (shouldAudit && !isExcepted) {
+        if (shouldAudit && !isExcepted && !isIgnoredModule) {
           acc.unhandledIds.push(Number(cur.id));
         }
 
@@ -113,6 +120,7 @@ export function processAuditJson(jsonBuffer = '', auditLevel: AuditLevel = 'info
         get(cur, 'via', []).forEach((vul: v7VulnerabilityVia | string) => {
           // The vulnerability ID is labeled as `source`
           const id = get(vul, 'source', '');
+          const moduleName = get(vul, 'name', '');
 
           // Let's skip if ID is a string (module name), and only focus on the root vulnerabilities
           if (!id || typeof id === 'string' || typeof vul === 'string') {
@@ -121,22 +129,26 @@ export function processAuditJson(jsonBuffer = '', auditLevel: AuditLevel = 'info
 
           const shouldAudit = mapLevelToNumber(vul.severity) >= mapLevelToNumber(auditLevel);
           const isExcepted = exceptionIds.includes(id);
+          const isIgnoredModule = modulesToIgnore.includes(moduleName);
 
           // Record this vulnerability into the report, and highlight it using yellow color if it's new
           acc.report.push([
-            color(String(id), isExcepted ? '' : 'yellow'),
-            color(vul.name, isExcepted ? '' : 'yellow'),
-            color(vul.title, isExcepted ? '' : 'yellow'),
-            color(trimArray(get(cur, 'nodes', []).map(shortenNodePath), MAX_PATHS_SIZE).join('\n'), isExcepted ? '' : 'yellow'),
-            color(vul.severity, isExcepted ? '' : 'yellow', getSeverityBgColor(vul.severity)),
-            color(vul.url, isExcepted ? '' : 'yellow'),
-            isExcepted ? 'y' : color('n', 'yellow'),
+            color(String(id), isExcepted || isIgnoredModule ? '' : 'yellow'),
+            color(vul.name, isExcepted || isIgnoredModule ? '' : 'yellow'),
+            color(vul.title, isExcepted || isIgnoredModule ? '' : 'yellow'),
+            color(
+              trimArray(get(cur, 'nodes', []).map(shortenNodePath), MAX_PATHS_SIZE).join('\n'),
+              isExcepted || isIgnoredModule ? '' : 'yellow',
+            ),
+            color(vul.severity, isExcepted || isIgnoredModule ? '' : 'yellow', getSeverityBgColor(vul.severity)),
+            color(vul.url, isExcepted || isIgnoredModule ? '' : 'yellow'),
+            isExcepted || isIgnoredModule ? 'y' : color('n', 'yellow'),
           ]);
 
           acc.vulnerabilityIds.push(id);
 
           // Found unhandled vulnerabilities
-          if (shouldAudit && !isExcepted) {
+          if (shouldAudit && !isExcepted && !isIgnoredModule) {
             acc.unhandledIds.push(id);
           }
         });

--- a/test/__mocks__/exception-table-data.json
+++ b/test/__mocks__/exception-table-data.json
@@ -1,17 +1,92 @@
 [
-  ["1165", "\u001b[32mactive\u001b[0m", "", ""],
-  ["1890", "\u001b[32mactive\u001b[0m", "", ""],
-  ["975", "\u001b[31mexpired\u001b[0m", "Thu, 11 Mar 2021 11:28:54 GMT", ""],
-  ["976", "\u001b[33minactive\u001b[0m", "", ""],
-  ["985", "\u001b[32mactive\u001b[0m", "", ""],
-  ["1084", "\u001b[31mexpired\u001b[0m", "Thu, 11 Mar 2021 11:28:54 GMT", "Inactive package; consider replacing it."],
-  ["1179", "\u001b[31mexpired\u001b[0m", "Thu, 11 Mar 2021 11:28:54 GMT", ""],
-  ["1213", "\u001b[32mactive\u001b[0m", "", "Ignored since we don't use xxx method"],
-  ["1556", "\u001b[31mexpired\u001b[0m", "Thu, 11 Mar 2021 11:28:54 GMT", "Issue: https://github.com/jeemok/better-npm-audit/issues/28"],
-  ["1651", "\u001b[31mexpired\u001b[0m", "Thu, 11 Mar 2021 11:28:54 GMT", "This will be fixed by the maintainers by June 14"],
-  ["1654", "\u001b[32mactive\u001b[0m", "Fri, 31 Dec 2021 16:00:00 GMT", ""],
-  ["2000", "\u001b[32mactive\u001b[0m", "\u001b[33mMon, 01 Jan 2024 00:00:00 GMT\u001b[0m", ""],
-  ["2001", "\u001b[32mactive\u001b[0m", "\u001b[31mTue, 01 Jan 2030 00:00:00 GMT\u001b[0m", ""],
-  ["2100", "\u001b[32mactive\u001b[0m", "", "Unused"],
-  ["Note", "\u001b[31minvalid\u001b[0m", "", "personal note"]
+  [
+    "1165",
+    "\u001b[32mactive\u001b[0m",
+    "",
+    ""
+  ],
+  [
+    "1890",
+    "\u001b[32mactive\u001b[0m",
+    "",
+    ""
+  ],
+  [
+    "975",
+    "\u001b[31mexpired\u001b[0m",
+    "Thu, 11 Mar 2021 11:28:54 GMT",
+    ""
+  ],
+  [
+    "976",
+    "\u001b[33minactive\u001b[0m",
+    "",
+    ""
+  ],
+  [
+    "985",
+    "\u001b[32mactive\u001b[0m",
+    "",
+    ""
+  ],
+  [
+    "1084",
+    "\u001b[31mexpired\u001b[0m",
+    "Thu, 11 Mar 2021 11:28:54 GMT",
+    "Inactive package; consider replacing it."
+  ],
+  [
+    "1179",
+    "\u001b[31mexpired\u001b[0m",
+    "Thu, 11 Mar 2021 11:28:54 GMT",
+    ""
+  ],
+  [
+    "1213",
+    "\u001b[32mactive\u001b[0m",
+    "",
+    "Ignored since we don't use xxx method"
+  ],
+  [
+    "1556",
+    "\u001b[31mexpired\u001b[0m",
+    "Thu, 11 Mar 2021 11:28:54 GMT",
+    "Issue: https://github.com/jeemok/better-npm-audit/issues/28"
+  ],
+  [
+    "1651",
+    "\u001b[31mexpired\u001b[0m",
+    "Thu, 11 Mar 2021 11:28:54 GMT",
+    "This will be fixed by the maintainers by June 14"
+  ],
+  [
+    "1654",
+    "\u001b[31mexpired\u001b[0m",
+    "Fri, 31 Dec 2021 16:00:00 GMT",
+    ""
+  ],
+  [
+    "2000",
+    "\u001b[32mactive\u001b[0m",
+    "\u001b[33mMon, 01 Jan 2024 00:00:00 GMT\u001b[0m",
+    ""
+  ],
+  [
+    "2001",
+    "\u001b[32mactive\u001b[0m",
+    "\u001b[31mTue, 01 Jan 2030 00:00:00 GMT\u001b[0m",
+    ""
+  ],
+  [
+    "2100",
+    "\u001b[32mactive\u001b[0m",
+    "",
+    "Unused"
+  ],
+  [
+    "Note",
+    "\u001b[31minvalid\u001b[0m",
+    "",
+    "personal note"
+  ]
 ]

--- a/test/handlers/flags.test.ts
+++ b/test/handlers/flags.test.ts
@@ -191,7 +191,38 @@ describe('Flags', () => {
       expect(callbackStub.calledWith(auditCommand, 'critical')).to.equal(true);
 
       // Clean up
-      process.env.NPM_CONFIG_AUDIT_LEVEL = undefined;
+      delete process.env.NPM_CONFIG_AUDIT_LEVEL;
+    });
+  });
+
+  describe('--module-ignore', () => {
+    it('should be able to pass module names using the command flag smoothly', () => {
+      const callbackStub = sinon.stub();
+      const options = { moduleIgnore: 'lodash,moment' };
+      const auditCommand = 'npm audit';
+      const auditLevel = 'info';
+      const exceptionIds: number[] = [];
+      const modulesToIgnore = ['lodash', 'moment'];
+
+      expect(callbackStub.called).to.equal(false);
+      handleInput(options, callbackStub);
+      expect(callbackStub.called).to.equal(true);
+      expect(callbackStub.calledWith(auditCommand, auditLevel, exceptionIds, modulesToIgnore)).to.equal(true);
+
+      // with space
+      options.moduleIgnore = 'lodash, moment';
+      handleInput(options, callbackStub);
+      expect(callbackStub.calledWith(auditCommand, auditLevel, exceptionIds, modulesToIgnore)).to.equal(true);
+
+      // invalid exceptions
+      options.moduleIgnore = 'lodash,undefined,moment';
+      handleInput(options, callbackStub);
+      expect(callbackStub.calledWith(auditCommand, auditLevel, exceptionIds, modulesToIgnore)).to.equal(true);
+
+      // invalid null
+      options.moduleIgnore = 'lodash,null,moment';
+      handleInput(options, callbackStub);
+      expect(callbackStub.calledWith(auditCommand, auditLevel, exceptionIds, modulesToIgnore)).to.equal(true);
     });
   });
 });

--- a/test/handlers/handleFinish.test.ts
+++ b/test/handlers/handleFinish.test.ts
@@ -13,11 +13,12 @@ describe('Events handling', () => {
     const jsonBuffer = '';
     const auditLevel = 'info';
     const exceptionIds: number[] = [];
+    const modulesToIgnore: string[] = [];
 
     expect(processStub.called).to.equal(false);
     expect(consoleStub.called).to.equal(false);
 
-    handleFinish(jsonBuffer, auditLevel, exceptionIds);
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
 
     expect(processStub.called).to.equal(true);
     expect(processStub.calledWith(1)).to.equal(true);
@@ -35,9 +36,10 @@ describe('Events handling', () => {
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER_EMPTY);
     const auditLevel = 'info';
     const exceptionIds: number[] = [];
+    const modulesToIgnore: string[] = [];
 
     expect(consoleStub.called).to.equal(false);
-    handleFinish(jsonBuffer, auditLevel, exceptionIds);
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
 
     expect(processStub.called).to.equal(true);
     expect(processStub.calledWith(0)).to.equal(true);
@@ -55,9 +57,10 @@ describe('Events handling', () => {
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER);
     const auditLevel = 'info';
     const exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 1556, 1589];
+    const modulesToIgnore: string[] = [];
 
     expect(consoleStub.called).to.equal(false);
-    handleFinish(jsonBuffer, auditLevel, exceptionIds);
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
 
     expect(processStub.called).to.equal(true);
     expect(processStub.calledWith(0)).to.equal(true);
@@ -76,12 +79,13 @@ describe('Events handling', () => {
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER);
     const auditLevel = 'info';
     const exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555];
+    const modulesToIgnore: string[] = [];
 
     expect(processStub.called).to.equal(false);
     expect(consoleErrorStub.called).to.equal(false);
     expect(consoleInfoStub.called).to.equal(false);
 
-    handleFinish(jsonBuffer, auditLevel, exceptionIds);
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
 
     expect(processStub.called).to.equal(true);
     expect(consoleErrorStub.called).to.equal(true);
@@ -102,6 +106,7 @@ describe('Events handling', () => {
     const consoleInfoStub = sinon.stub(console, 'info');
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER);
     const auditLevel = 'info';
+    const modulesToIgnore: string[] = [];
 
     let exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 2001];
 
@@ -110,7 +115,7 @@ describe('Events handling', () => {
     expect(consoleWarnStub.called).to.equal(false);
     expect(consoleInfoStub.called).to.equal(false);
 
-    handleFinish(jsonBuffer, auditLevel, exceptionIds);
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
 
     expect(processStub.called).to.equal(true);
     expect(processStub.calledWith(1)).to.equal(true);
@@ -127,7 +132,7 @@ describe('Events handling', () => {
 
     // Message for multiple unused exceptions
     exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 2001, 2002];
-    handleFinish(jsonBuffer, auditLevel, exceptionIds);
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
     // eslint-disable-next-line max-len
     message = `2 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001, 2002. They can be removed from the .nsprc file or --exclude -x flags.`;
     expect(consoleWarnStub.calledWith(message)).to.equal(true);

--- a/test/handlers/handleFinish.test.ts
+++ b/test/handlers/handleFinish.test.ts
@@ -51,13 +51,13 @@ describe('Events handling', () => {
     consoleStub.restore();
   });
 
-  it('should be able to except vulnerabilities properly', () => {
+  it('should be able to except vulnerabilities by id properly', () => {
     const processStub = sinon.stub(process, 'exit');
     const consoleStub = sinon.stub(console, 'info');
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER);
     const auditLevel = 'info';
-    const exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 1556, 1589];
-    const modulesToIgnore: string[] = [];
+    const exceptionIds = [975, 985, 1179, 1213, 1500, 1523, 1555, 1556, 1589];
+    const modulesToIgnore = ['swagger-ui', 'mem'];
 
     expect(consoleStub.called).to.equal(false);
     handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
@@ -99,14 +99,14 @@ describe('Events handling', () => {
     consoleInfoStub.restore();
   });
 
-  it('should inform the developer when exceptionsIds are unused', () => {
+  it('should inform the developer when exceptionsIds and ignoredModules are unused', () => {
     const processStub = sinon.stub(process, 'exit');
     const consoleErrorStub = sinon.stub(console, 'error');
     const consoleWarnStub = sinon.stub(console, 'warn');
     const consoleInfoStub = sinon.stub(console, 'info');
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER);
     const auditLevel = 'info';
-    const modulesToIgnore: string[] = [];
+    let modulesToIgnore = ['fakeModule1', 'fakeModule2'];
 
     let exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 2001];
 
@@ -127,14 +127,15 @@ describe('Events handling', () => {
 
     // Message for one unused exception
     // eslint-disable-next-line max-len
-    let message = `1 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001. It can be removed from the .nsprc file or --exclude -x flags.`;
+    let message = `1 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001. It can be removed from the .nsprc file or --exclude -x flags. 2 of the ignored modules did not match any of the found vulnerabilites: fakeModule1, fakeModule2. They can be removed from the --module-ignore -m flags.`;
     expect(consoleWarnStub.calledWith(message)).to.equal(true);
 
     // Message for multiple unused exceptions
     exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 2001, 2002];
+    modulesToIgnore = ['fakeModule1'];
     handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
     // eslint-disable-next-line max-len
-    message = `2 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001, 2002. They can be removed from the .nsprc file or --exclude -x flags.`;
+    message = `2 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001, 2002. They can be removed from the .nsprc file or --exclude -x flags. 1 of the ignored modules did not match any of the found vulnerabilites: fakeModule1. It can be removed from the --module-ignore -m flags.`;
     expect(consoleWarnStub.calledWith(message)).to.equal(true);
 
     processStub.restore();

--- a/test/utils/vulnerability.test.ts
+++ b/test/utils/vulnerability.test.ts
@@ -39,7 +39,7 @@ describe('Vulnerability utils', () => {
       const cmdExceptions = [1165, 1890];
       expect(consoleStub.called).to.equal(false);
       const result = getExceptionsIds(NSPRC, cmdExceptions);
-      expect(result).to.have.length(8).and.deep.equal([1165, 1890, 985, 1213, 1654, 2000, 2001, 2100]);
+      expect(result).to.have.length(7).and.deep.equal([1165, 1890, 985, 1213, 2000, 2001, 2100]);
       expect(consoleStub.called).to.equal(true); // Print security report
       consoleStub.restore();
     });
@@ -51,25 +51,25 @@ describe('Vulnerability utils', () => {
       const result = processExceptions(NSPRC, cmdExceptions);
 
       expect(result).to.have.property('exceptionIds');
-      expect(result.exceptionIds).to.have.length(8).and.to.deep.equal([1165, 1890, 985, 1213, 1654, 2000, 2001, 2100]);
+      expect(result.exceptionIds).to.have.length(7).and.to.deep.equal([1165, 1890, 985, 1213, 2000, 2001, 2100]);
       expect(result).to.have.property('report');
       expect(result.report).to.have.length(15).and.to.deep.equal(EXCEPTION_TABLE_DATA);
     });
 
     it('should be able to filter active exceptions and label correctly', () => {
       const result = processExceptions(NSPRC);
-      expect(result).to.have.property('exceptionIds').and.to.have.length(6);
+      expect(result).to.have.property('exceptionIds').and.to.have.length(5);
       expect(result).to.have.property('report');
 
       const activeExceptionIds = result.report
         .filter((exception: string[]) => exception[1] === '\u001b[32mactive\u001b[0m')
         .map((each: (string | number)[]) => Number(each[0]));
-      expect(activeExceptionIds).to.have.length(6).to.deep.equal([985, 1213, 1654, 2000, 2001, 2100]);
+      expect(activeExceptionIds).to.have.length(5).to.deep.equal([985, 1213, 2000, 2001, 2100]);
     });
 
     it('should be able to filter inactive exceptions and label correctly', () => {
       const result = processExceptions(NSPRC);
-      expect(result).to.have.property('exceptionIds').and.to.have.length(6);
+      expect(result).to.have.property('exceptionIds').and.to.have.length(5);
       expect(result).to.have.property('report');
 
       const activeExceptionIds = result.report
@@ -81,13 +81,12 @@ describe('Vulnerability utils', () => {
     it('should be able to filter expired exceptions and label correctly', () => {
       const dateStub = sinon.stub(Date, 'now').returns(new Date(Date.UTC(2021, 6, 1)).valueOf());
       const result = processExceptions(NSPRC);
-      expect(result).to.have.property('exceptionIds').and.to.have.length(6);
-      expect(result).to.have.property('report');
-
+      expect(result).to.have.property('exceptionIds').and.to.have.length(5);
+      expect(result).to.have.property('report').and.to.have.length(13);
       const activeExceptionIds = result.report
         .filter((exception: string[]) => exception[1] === '\u001b[31mexpired\u001b[0m')
         .map((each: (string | number)[]) => Number(each[0]));
-      expect(activeExceptionIds).to.have.length(5).to.deep.equal([975, 1084, 1179, 1556, 1651]);
+      expect(activeExceptionIds).to.have.length(6).to.deep.equal([975, 1084, 1179, 1556, 1651, 1654]);
 
       // Clean up
       dateStub.restore();
@@ -95,7 +94,7 @@ describe('Vulnerability utils', () => {
 
     it('should be able to filter invalid exceptions and label correctly', () => {
       const result = processExceptions(NSPRC);
-      expect(result).to.have.property('exceptionIds').and.to.have.length(6);
+      expect(result).to.have.property('exceptionIds').and.to.have.length(5);
       expect(result).to.have.property('report');
 
       const activeExceptionIds = result.report

--- a/test/utils/vulnerability.test.ts
+++ b/test/utils/vulnerability.test.ts
@@ -113,6 +113,8 @@ describe('Vulnerability utils', () => {
 
         expect(result).to.have.property('vulnerabilityIds');
         expect(result.vulnerabilityIds).to.have.length(0).and.to.deep.equal([]);
+        expect(result).to.have.property('vulnerabilityModules');
+        expect(result.vulnerabilityModules).to.have.length(0).and.to.deep.equal([]);
         expect(result).to.have.property('unhandledIds');
         expect(result.unhandledIds).to.have.length(0).and.to.deep.equal([]);
         expect(result).to.have.property('report');
@@ -128,10 +130,10 @@ describe('Vulnerability utils', () => {
           .and.to.have.length(11)
           .and.to.deep.equal([975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 1556, 1589]);
 
-        expect(processAuditJson(jsonString, auditLevel, [975, 1179, 1589]))
+        expect(processAuditJson(jsonString, auditLevel, [975, 1179, 1589], ['dot-prop']))
           .to.have.property('unhandledIds')
-          .and.to.have.length(8)
-          .and.to.deep.equal([976, 985, 1084, 1213, 1500, 1523, 1555, 1556]);
+          .and.to.have.length(7)
+          .and.to.deep.equal([976, 985, 1084, 1500, 1523, 1555, 1556]);
       });
 
       it('should be able to list all the reported vulnerabilities', () => {
@@ -143,6 +145,10 @@ describe('Vulnerability utils', () => {
         expect(result.vulnerabilityIds)
           .to.have.length(11)
           .and.to.deep.equal([975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 1556, 1589]);
+        expect(result).to.have.property('vulnerabilityModules');
+        expect(result.vulnerabilityModules)
+          .to.have.length(9)
+          .and.to.deep.equal(['swagger-ui', 'mem', 'minimist', 'dot-prop', 'yargs-parser', 'lodash', 'bl', 'node-fetch', 'ini']);
       });
 
       it('should be able to generate a report of all the reported vulnerabilities', () => {
@@ -160,6 +166,7 @@ describe('Vulnerability utils', () => {
         const result = processAuditJson(jsonString, auditLevel);
 
         expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
@@ -172,6 +179,7 @@ describe('Vulnerability utils', () => {
         const result = processAuditJson(jsonString, auditLevel);
 
         expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
@@ -184,6 +192,7 @@ describe('Vulnerability utils', () => {
         const result = processAuditJson(jsonString, auditLevel);
 
         expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
@@ -196,6 +205,7 @@ describe('Vulnerability utils', () => {
         const result = processAuditJson(jsonString, auditLevel);
 
         expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
@@ -208,6 +218,7 @@ describe('Vulnerability utils', () => {
         const result = processAuditJson(jsonString, auditLevel);
 
         expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
@@ -223,6 +234,8 @@ describe('Vulnerability utils', () => {
 
         expect(result).to.have.property('vulnerabilityIds');
         expect(result.vulnerabilityIds).to.have.length(0).and.to.deep.equal([]);
+        expect(result).to.have.property('vulnerabilityModules');
+        expect(result.vulnerabilityModules).to.have.length(0).and.to.deep.equal([]);
         expect(result).to.have.property('unhandledIds');
         expect(result.unhandledIds).to.have.length(0).and.to.deep.equal([]);
         expect(result).to.have.property('report');
@@ -238,10 +251,10 @@ describe('Vulnerability utils', () => {
           .and.to.have.length(11)
           .and.to.deep.equal([1555, 1213, 1589, 1523, 1084, 1179, 1556, 975, 976, 985, 1500]);
 
-        expect(processAuditJson(jsonString, auditLevel, [975, 1179, 1589]))
+        expect(processAuditJson(jsonString, auditLevel, [975, 1179, 1589], ['dot-prop', 'yargs-parser']))
           .to.have.property('unhandledIds')
-          .and.to.have.length(8)
-          .and.to.deep.equal([1555, 1213, 1523, 1084, 1556, 976, 985, 1500]);
+          .and.to.have.length(6)
+          .and.to.deep.equal([1555, 1523, 1084, 1556, 976, 985]);
       });
 
       it('should be able to list all the reported vulnerabilities', () => {
@@ -253,6 +266,10 @@ describe('Vulnerability utils', () => {
         expect(result.vulnerabilityIds)
           .to.have.length(11)
           .and.to.deep.equal([1555, 1213, 1589, 1523, 1084, 1179, 1556, 975, 976, 985, 1500]);
+        expect(result).to.have.property('vulnerabilityModules');
+        expect(result.vulnerabilityModules)
+          .to.have.length(9)
+          .and.to.deep.equal(['bl', 'dot-prop', 'ini', 'lodash', 'mem', 'minimist', 'node-fetch', 'swagger-ui', 'yargs-parser']);
       });
 
       it('should be able to generate a report of all the reported vulnerabilities', () => {
@@ -271,6 +288,7 @@ describe('Vulnerability utils', () => {
         const result = processAuditJson(jsonString, auditLevel);
 
         expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
@@ -283,6 +301,7 @@ describe('Vulnerability utils', () => {
         const result = processAuditJson(jsonString, auditLevel);
 
         expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
@@ -295,6 +314,7 @@ describe('Vulnerability utils', () => {
         const result = processAuditJson(jsonString, auditLevel);
 
         expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
@@ -307,6 +327,7 @@ describe('Vulnerability utils', () => {
         const result = processAuditJson(jsonString, auditLevel);
 
         expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
@@ -319,6 +340,7 @@ describe('Vulnerability utils', () => {
         const result = processAuditJson(jsonString, auditLevel);
 
         expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');


### PR DESCRIPTION
**Description**
To address feature request: https://github.com/jeemok/better-npm-audit/issues/69

This fixes the issue where vulnerabilities disputed by package owners causes ever changing vulnerability ids in the audit report. In my repo I have to a seemingly infinite number of ids to my `.nsprc` to manage the currently disputed `lodash` issue: 
<img width="1461" alt="Screen Shot 2022-02-20 at 5 43 33 PM" src="https://user-images.githubusercontent.com/89814961/154875829-aa29cda7-d910-423f-ad69-f999dee9c210.png">

Having a single flag to ignore `lodash` rather than w/e next id pops up for the same vulnerability is a huge time saver in a team environment :).

**TODO**
- [x] Add module-ignore flag
- [x] fix unit tests breaking due to expiry dates (unrelated to addition of flag)
- [x] README update
- [x] add unit tests for new flag
- [x] test flag locally in consuming repo

**Screenshots**
Tested via `npm link`
**No flags, remove nsprc code for lodash (1 module)**:
<img width="1431" alt="no-flags" src="https://user-images.githubusercontent.com/89814961/154874872-9fe8cc8e-0ef3-4e46-afdc-7ca2758cdc61.png">

**`-m` flag 1 module**:
<img width="1576" alt="m-flag" src="https://user-images.githubusercontent.com/89814961/154874910-881191fb-5497-49cd-aa85-005fd8e0eff6.png">

**`--module-ignore` flag 1 module**:
<img width="1593" alt="module-ignore-flag" src="https://user-images.githubusercontent.com/89814961/154874925-fd8e291f-db96-4a23-bd8f-00746c5d6445.png">

**`--module-ignore` flag 2 modules (removed `lodash` and `hermes-engine` ids from `nsprc`)**:
<img width="1589" alt="2 modules" src="https://user-images.githubusercontent.com/89814961/154874981-0270cb0b-e5f7-4d32-b30f-88a6fd4a7d9d.png">

@jeemok @GrzesiekP @IPWright83 