### PR TITLE
Update 'isExcepted' to check for CVE id

### DIFF
--- a/src/types/general.d.ts
+++ b/src/types/general.d.ts
@@ -19,6 +19,7 @@ export interface v6Advisories {
 
 export interface v6Advisory {
   readonly id: string;
+  readonly cves: string[];
   // eslint-disable-next-line camelcase
   readonly module_name: string;
   readonly title: string;

--- a/src/utils/vulnerability.ts
+++ b/src/utils/vulnerability.ts
@@ -76,7 +76,16 @@ export function processAuditJson(
     return Object.values(advisories).reduce(
       (acc: ProcessedResult, cur: v6Advisory) => {
         const shouldAudit = mapLevelToNumber(cur.severity) >= mapLevelToNumber(auditLevel);
-        const isExcepted = exceptionIds.includes(Number(cur.id));
+        let isExcepted: boolean = false;
+
+        if (cur.id && exceptionIds.includes(Number(cur.id)) || // NPM v6 contains 'id's to use
+            (cur.cves && exceptionIds.filter(id => cur.cves.includes(id)).length > 0) || // NPM v6 can also have an array of cve id's
+            (cur.via && cur.via[0].source && exceptionIds.includes(Number(cur.via[0].source))) || //auditReportVersion: 2. Check via.source for id
+            (cur.via && cur.via[0].url && exceptionIds.filter(id => cur.via[0].url.contains(id)).length > 0 )) //auditReportVersion: 2. Check via.url for github id
+        {
+            isExcepted = true;
+        }
+
         const isIgnoredModule = modulesToIgnore.includes(cur.module_name);
 
         // Record this vulnerability into the report, and highlight it using yellow color if it's new

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
         "target": "es5",
         "module": "commonjs",
         "lib": [
-            "ES6",
-            "ES2015"
+            "ES2018"
         ],
         "outDir": "lib",
         "strict": true,


### PR DESCRIPTION
Making this PR because every time a vulnerability get's updated the ID seems to change. So I constantly have to update my .nsprc file with the new ID. 

It looks like the JSON output from the audit contains a `cves` property with the GitHub CVE ID's. So would something like this work? 

So if we don't have a match to the cur.id check the cve id's. Not ideal having numeric a non-numeric ID's but that should allow the CVE ID to be used in the .nsprc as well as the other standard ID's.