### PR TITLE
Allow vulnerabilities to be identifed by URL

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@
 import { Command } from 'commander';
 import { exec } from 'child_process';
 
-import { AuditLevel, CommandOptions } from 'src/types';
+import { AuditLevel, CommandOptions, VulnerabilityId } from 'src/types';
 
 import handleInput from './src/handlers/handleInput';
 import handleFinish from './src/handlers/handleFinish';
@@ -20,7 +20,7 @@ const program = new Command();
  * @param  {Array}  exceptionIds    List of vulnerability IDs to exclude
  * @param  {Array} modulesToIgnore   List of vulnerable modules to ignore in audit results
  */
-export function callback(auditCommand: string, auditLevel: AuditLevel, exceptionIds: number[], modulesToIgnore: string[]): void {
+export function callback(auditCommand: string, auditLevel: AuditLevel, exceptionIds: VulnerabilityId[], modulesToIgnore: string[]): void {
   // Increase the default max buffer size (1 MB)
   const audit = exec(`${auditCommand} --json`, { maxBuffer: MAX_BUFFER_SIZE });
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "preaudit": "npm run build",
-    "audit": "node lib audit -x 1004946,1006897",
+    "audit": "node lib audit -x https://github.com/advisories/GHSA-qrpm-p2h7-hrv2,https://github.com/advisories/GHSA-93q8-gq69-wqmw",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "lint": "eslint .",
     "qc": "npm run test && npm run lint",

--- a/src/handlers/handleFinish.ts
+++ b/src/handlers/handleFinish.ts
@@ -1,4 +1,4 @@
-import { AuditLevel } from 'src/types';
+import { AuditLevel, VulnerabilityId } from 'src/types';
 import { printSecurityReport } from '../utils/print';
 import { processAuditJson } from '../utils/vulnerability';
 
@@ -10,8 +10,13 @@ import { processAuditJson } from '../utils/vulnerability';
  * @param  {Array} modulesToIgnore   List of vulnerable modules to ignore in audit results
  * @return {undefined}
  */
-export default function handleFinish(jsonBuffer: string, auditLevel: AuditLevel, exceptionIds: number[], modulesToIgnore: string[]): void {
-  const { unhandledIds, vulnerabilityIds, vulnerabilityModules, report, failed } = processAuditJson(
+export default function handleFinish(
+  jsonBuffer: string,
+  auditLevel: AuditLevel,
+  exceptionIds: VulnerabilityId[],
+  modulesToIgnore: string[],
+): void {
+  const { unhandledIds, vulnerabilityIds, vulnerabilityURLs, vulnerabilityModules, report, failed } = processAuditJson(
     jsonBuffer,
     auditLevel,
     exceptionIds,
@@ -32,7 +37,13 @@ export default function handleFinish(jsonBuffer: string, auditLevel: AuditLevel,
   }
 
   // Grab any un-filtered vulnerabilities at the appropriate level
-  const unusedExceptionIds = exceptionIds.filter((id) => !vulnerabilityIds.includes(id));
+  const unusedExceptionIds = exceptionIds.filter((id) => {
+    if (typeof id === 'number') {
+      return !vulnerabilityIds.includes(id);
+    } else {
+      return !vulnerabilityURLs.includes(id);
+    }
+  });
   const unusedIgnoredModules = modulesToIgnore.filter((moduleName) => !vulnerabilityModules.includes(moduleName));
 
   const messages = [

--- a/src/handlers/handleInput.ts
+++ b/src/handlers/handleInput.ts
@@ -1,5 +1,5 @@
 import get from 'lodash.get';
-import { AuditLevel, CommandOptions } from 'src/types';
+import { AuditLevel, CommandOptions, VulnerabilityId } from 'src/types';
 import { isWholeNumber } from '../utils/common';
 import { readFile } from '../utils/file';
 import { getExceptionsIds } from '../utils/vulnerability';
@@ -9,7 +9,10 @@ import { getExceptionsIds } from '../utils/vulnerability';
  * @param  {Object} options     User's command options or flags
  * @param  {Function} fn        The function to handle the inputs
  */
-export default function handleInput(options: CommandOptions, fn: (T1: string, T2: AuditLevel, T3: number[], T4: string[]) => void): void {
+export default function handleInput(
+  options: CommandOptions,
+  fn: (T1: string, T2: AuditLevel, T3: VulnerabilityId[], T4: string[]) => void,
+): void {
   // Generate NPM Audit command
   const auditCommand: string = [
     'npm audit',
@@ -27,7 +30,7 @@ export default function handleInput(options: CommandOptions, fn: (T1: string, T2
   // Get the exceptions
   const nsprc = readFile('.nsprc');
   const cmdExceptions: number[] = get(options, 'exclude', '').split(',').filter(isWholeNumber).map(Number);
-  const exceptionIds: number[] = getExceptionsIds(nsprc, cmdExceptions);
+  const exceptionIds: VulnerabilityId[] = getExceptionsIds(nsprc, cmdExceptions);
   const cmdModuleIgnore: string[] = get(options, 'moduleIgnore', '').split(',');
 
   fn(auditCommand, auditLevel, exceptionIds, cmdModuleIgnore);

--- a/src/handlers/handleInput.ts
+++ b/src/handlers/handleInput.ts
@@ -1,6 +1,6 @@
 import get from 'lodash.get';
 import { AuditLevel, CommandOptions, VulnerabilityId } from 'src/types';
-import { isWholeNumber } from '../utils/common';
+import { isWholeNumber, validateURL } from '../utils/common';
 import { readFile } from '../utils/file';
 import { getExceptionsIds } from '../utils/vulnerability';
 
@@ -29,7 +29,15 @@ export default function handleInput(
 
   // Get the exceptions
   const nsprc = readFile('.nsprc');
-  const cmdExceptions: number[] = get(options, 'exclude', '').split(',').filter(isWholeNumber).map(Number);
+  const cmdExceptions: VulnerabilityId[] = get(options, 'exclude', '')
+    .split(',')
+    .filter((s) => isWholeNumber(s) || validateURL(s))
+    .map((s) => {
+      if (isWholeNumber(s)) {
+        return Number(s);
+      }
+      return s;
+    });
   const exceptionIds: VulnerabilityId[] = getExceptionsIds(nsprc, cmdExceptions);
   const cmdModuleIgnore: string[] = get(options, 'moduleIgnore', '').split(',');
 

--- a/src/types/general.d.ts
+++ b/src/types/general.d.ts
@@ -53,12 +53,15 @@ export interface v7VulnerabilityVia {
 export interface ProcessedResult {
   readonly unhandledIds: number[];
   readonly vulnerabilityIds: number[];
+  readonly vulnerabilityURLs: string[];
   readonly vulnerabilityModules: string[];
   readonly report: string[][];
   readonly failed?: boolean;
 }
 
+type VulnerabilityId = number | string;
+
 export interface ProcessedReport {
-  readonly exceptionIds: number[];
+  readonly exceptionIds: VulnerabilityId[];
   readonly report: string[][];
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,3 +1,5 @@
+import { URL } from 'url';
+
 /**
  * @param  {String | Number | Null | Boolean} value     The input number
  * @return {Boolean}                                    Returns true if the input is a whole number
@@ -10,6 +12,21 @@ export function isWholeNumber(value: string | number | null | undefined): boolea
     return false;
   }
   return Number(value) % 1 === 0;
+}
+
+/**
+ * Validates whether a string is a URL or not.
+ *
+ * @param {String} id String to validate.
+ * @return {Boolean} True if URL; false otherwise.
+ */
+export function validateURL(id: string): boolean {
+  try {
+    new URL(id);
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 /**

--- a/src/utils/vulnerability.ts
+++ b/src/utils/vulnerability.ts
@@ -4,6 +4,7 @@ import { isJsonString, trimArray, shortenNodePath } from './common';
 import { color, getSeverityBgColor } from './color';
 import { printExceptionReport } from './print';
 import { analyzeExpiry } from './date';
+import { URL } from 'url';
 
 import {
   NpmAuditJson,
@@ -16,6 +17,7 @@ import {
   NsprcFile,
   AuditLevel,
   AuditNumber,
+  VulnerabilityId,
 } from 'src/types';
 
 const MAX_PATHS_SIZE = 5;
@@ -53,13 +55,14 @@ export function mapLevelToNumber(auditLevel: AuditLevel | string): AuditNumber {
 export function processAuditJson(
   jsonBuffer = '',
   auditLevel: AuditLevel = 'info',
-  exceptionIds: number[] = [],
+  exceptionIds: VulnerabilityId[] = [],
   modulesToIgnore: string[] = [],
 ): ProcessedResult {
   if (!isJsonString(jsonBuffer)) {
     return {
       unhandledIds: [],
       vulnerabilityIds: [],
+      vulnerabilityURLs: [],
       vulnerabilityModules: [],
       report: [],
       failed: true,
@@ -76,7 +79,7 @@ export function processAuditJson(
     return Object.values(advisories).reduce(
       (acc: ProcessedResult, cur: v6Advisory) => {
         const shouldAudit = mapLevelToNumber(cur.severity) >= mapLevelToNumber(auditLevel);
-        const isExcepted = exceptionIds.includes(Number(cur.id));
+        const isExcepted = exceptionIds.includes(Number(cur.id)) || exceptionIds.includes(cur.url);
         const isIgnoredModule = modulesToIgnore.includes(cur.module_name);
 
         // Record this vulnerability into the report, and highlight it using yellow color if it's new
@@ -97,6 +100,7 @@ export function processAuditJson(
         ]);
 
         acc.vulnerabilityIds.push(Number(cur.id));
+        acc.vulnerabilityURLs.push(cur.url);
         if (!acc.vulnerabilityModules.includes(cur.module_name)) {
           acc.vulnerabilityModules.push(cur.module_name);
         }
@@ -111,6 +115,7 @@ export function processAuditJson(
       {
         unhandledIds: [],
         vulnerabilityIds: [],
+        vulnerabilityURLs: [],
         vulnerabilityModules: [],
         report: [],
       },
@@ -126,6 +131,7 @@ export function processAuditJson(
           // The vulnerability ID is labeled as `source`
           const id = get(vul, 'source', '');
           const moduleName = get(vul, 'name', '');
+          const url = get(vul, 'url', '');
 
           // Let's skip if ID is a string (module name), and only focus on the root vulnerabilities
           if (!id || typeof id === 'string' || typeof vul === 'string') {
@@ -133,7 +139,7 @@ export function processAuditJson(
           }
 
           const shouldAudit = mapLevelToNumber(vul.severity) >= mapLevelToNumber(auditLevel);
-          const isExcepted = exceptionIds.includes(id);
+          const isExcepted = exceptionIds.includes(id) || exceptionIds.includes(url);
           const isIgnoredModule = modulesToIgnore.includes(moduleName);
 
           // Record this vulnerability into the report, and highlight it using yellow color if it's new
@@ -151,6 +157,7 @@ export function processAuditJson(
           ]);
 
           acc.vulnerabilityIds.push(id);
+          acc.vulnerabilityURLs.push(url);
           if (!acc.vulnerabilityModules.includes(moduleName)) {
             acc.vulnerabilityModules.push(moduleName);
           }
@@ -166,6 +173,7 @@ export function processAuditJson(
       {
         unhandledIds: [],
         vulnerabilityIds: [],
+        vulnerabilityURLs: [],
         vulnerabilityModules: [],
         report: [],
       },
@@ -174,6 +182,7 @@ export function processAuditJson(
   return {
     unhandledIds: [],
     vulnerabilityIds: [],
+    vulnerabilityURLs: [],
     vulnerabilityModules: [],
     report: [],
     failed: true,
@@ -186,7 +195,7 @@ export function processAuditJson(
  * @param  {Array}            cmdExceptions   Exceptions passed in via command line
  * @return {Array}                            List of found vulnerabilities
  */
-export function getExceptionsIds(nsprc?: NsprcFile | boolean, cmdExceptions: number[] = []): number[] {
+export function getExceptionsIds(nsprc?: NsprcFile | boolean, cmdExceptions: number[] = []): VulnerabilityId[] {
   // If file does not exists
   if (!nsprc || typeof nsprc !== 'object') {
     // If there are exceptions passed in from command line
@@ -208,6 +217,21 @@ export function getExceptionsIds(nsprc?: NsprcFile | boolean, cmdExceptions: num
 }
 
 /**
+ * Validates whether a string is a URL or not.
+ *
+ * @param {String} id String to validate.
+ * @return {Boolean} True if URL; false otherwise.
+ */
+function validateURL(id: string): boolean {
+  try {
+    new URL(id);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
  * Filter the given list in the `.nsprc` file for valid exceptions
  * @param  {Object} nsprc           The nsprc file content, contains exception info
  * @param  {Array}  cmdExceptions   Exceptions passed in via command line
@@ -218,6 +242,7 @@ export function processExceptions(nsprc: NsprcFile, cmdExceptions: number[] = []
     (acc: ProcessedReport, [id, details]: [string, string | NsprcConfigs]) => {
       const numberId = Number(id);
       const isValidId = !isNaN(numberId);
+      const isValidURL = validateURL(id);
       const isActive = Boolean(get(details, 'active', true)); // default to true
       const notes = typeof details === 'string' ? details : get(details, 'notes', '');
       const { valid, expired, years } = analyzeExpiry(get(details, 'expiry'));
@@ -226,7 +251,7 @@ export function processExceptions(nsprc: NsprcFile, cmdExceptions: number[] = []
       let status = color('active', 'green');
       if (expired) {
         status = color('expired', 'red');
-      } else if (!isValidId || !valid) {
+      } else if ((!isValidId && !isValidURL) || !valid) {
         status = color('invalid', 'red');
       } else if (!isActive) {
         status = color('inactive', 'yellow');
@@ -243,8 +268,12 @@ export function processExceptions(nsprc: NsprcFile, cmdExceptions: number[] = []
 
       acc.report.push([id, status, expiryDate, notes]);
 
-      if (isValidId && isActive && !expired) {
-        acc.exceptionIds.push(numberId);
+      if (isActive && !expired) {
+        if (isValidId) {
+          acc.exceptionIds.push(numberId);
+        } else if (isValidURL) {
+          acc.exceptionIds.push(id);
+        }
       }
 
       return acc;

--- a/src/utils/vulnerability.ts
+++ b/src/utils/vulnerability.ts
@@ -1,10 +1,9 @@
 import get from 'lodash.get';
 
-import { isJsonString, trimArray, shortenNodePath } from './common';
+import { isJsonString, trimArray, shortenNodePath, validateURL } from './common';
 import { color, getSeverityBgColor } from './color';
 import { printExceptionReport } from './print';
 import { analyzeExpiry } from './date';
-import { URL } from 'url';
 
 import {
   NpmAuditJson,
@@ -195,7 +194,7 @@ export function processAuditJson(
  * @param  {Array}            cmdExceptions   Exceptions passed in via command line
  * @return {Array}                            List of found vulnerabilities
  */
-export function getExceptionsIds(nsprc?: NsprcFile | boolean, cmdExceptions: number[] = []): VulnerabilityId[] {
+export function getExceptionsIds(nsprc?: NsprcFile | boolean, cmdExceptions: VulnerabilityId[] = []): VulnerabilityId[] {
   // If file does not exists
   if (!nsprc || typeof nsprc !== 'object') {
     // If there are exceptions passed in from command line
@@ -217,27 +216,12 @@ export function getExceptionsIds(nsprc?: NsprcFile | boolean, cmdExceptions: num
 }
 
 /**
- * Validates whether a string is a URL or not.
- *
- * @param {String} id String to validate.
- * @return {Boolean} True if URL; false otherwise.
- */
-function validateURL(id: string): boolean {
-  try {
-    new URL(id);
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
-
-/**
  * Filter the given list in the `.nsprc` file for valid exceptions
  * @param  {Object} nsprc           The nsprc file content, contains exception info
  * @param  {Array}  cmdExceptions   Exceptions passed in via command line
  * @return {Object}                 Processed vulnerabilities details
  */
-export function processExceptions(nsprc: NsprcFile, cmdExceptions: number[] = []): ProcessedReport {
+export function processExceptions(nsprc: NsprcFile, cmdExceptions: VulnerabilityId[] = []): ProcessedReport {
   return Object.entries(nsprc).reduce(
     (acc: ProcessedReport, [id, details]: [string, string | NsprcConfigs]) => {
       const numberId = Number(id);

--- a/test/handlers/handleFinish.test.ts
+++ b/test/handlers/handleFinish.test.ts
@@ -110,37 +110,39 @@ describe('Events handling', () => {
 
     let exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 2001];
 
-    expect(processStub.called).to.equal(false);
-    expect(consoleErrorStub.called).to.equal(false);
-    expect(consoleWarnStub.called).to.equal(false);
-    expect(consoleInfoStub.called).to.equal(false);
+    try {
+      expect(processStub.called).to.equal(false);
+      expect(consoleErrorStub.called).to.equal(false);
+      expect(consoleWarnStub.called).to.equal(false);
+      expect(consoleInfoStub.called).to.equal(false);
 
-    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
+      handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
 
-    expect(processStub.called).to.equal(true);
-    expect(processStub.calledWith(1)).to.equal(true);
-    expect(consoleErrorStub.called).to.equal(true);
-    expect(consoleErrorStub.calledWith('2 vulnerabilities found. Node security advisories: 1556, 1589')).to.equal(true);
+      expect(processStub.called).to.equal(true);
+      expect(processStub.calledWith(1)).to.equal(true);
+      expect(consoleErrorStub.called).to.equal(true);
+      expect(consoleErrorStub.calledWith('2 vulnerabilities found. Node security advisories: 1556, 1589')).to.equal(true);
 
-    expect(consoleInfoStub.called).to.equal(true); // Print security report
-    expect(consoleWarnStub.called).to.equal(true);
+      expect(consoleInfoStub.called).to.equal(true); // Print security report
+      expect(consoleWarnStub.called).to.equal(true);
 
-    // Message for one unused exception
-    // eslint-disable-next-line max-len
-    let message = `1 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001. It can be removed from the .nsprc file or --exclude -x flags. 2 of the ignored modules did not match any of the found vulnerabilites: fakeModule1, fakeModule2. They can be removed from the --module-ignore -m flags.`;
-    expect(consoleWarnStub.calledWith(message)).to.equal(true);
+      // Message for one unused exception
+      // eslint-disable-next-line max-len
+      let message = `1 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001. It can be removed from the .nsprc file or --exclude -x flags. 2 of the ignored modules did not match any of the found vulnerabilites: fakeModule1, fakeModule2. They can be removed from the --module-ignore -m flags.`;
+      expect(consoleWarnStub.calledWith(message)).to.equal(true);
 
-    // Message for multiple unused exceptions
-    exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 2001, 2002];
-    modulesToIgnore = ['fakeModule1'];
-    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
-    // eslint-disable-next-line max-len
-    message = `2 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001, 2002. They can be removed from the .nsprc file or --exclude -x flags. 1 of the ignored modules did not match any of the found vulnerabilites: fakeModule1. It can be removed from the --module-ignore -m flags.`;
-    expect(consoleWarnStub.calledWith(message)).to.equal(true);
-
-    processStub.restore();
-    consoleErrorStub.restore();
-    consoleWarnStub.restore();
-    consoleInfoStub.restore();
+      // Message for multiple unused exceptions
+      exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 2001, 2002];
+      modulesToIgnore = ['fakeModule1'];
+      handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
+      // eslint-disable-next-line max-len
+      message = `2 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001, 2002. They can be removed from the .nsprc file or --exclude -x flags. 1 of the ignored modules did not match any of the found vulnerabilites: fakeModule1. It can be removed from the --module-ignore -m flags.`;
+      expect(consoleWarnStub.calledWith(message)).to.equal(true);
+    } finally {
+      processStub.restore();
+      consoleErrorStub.restore();
+      consoleWarnStub.restore();
+      consoleInfoStub.restore();
+    }
   });
 });


### PR DESCRIPTION
Unfortunately, for mysterious reasons, the ids returned from the NPM
audit API have been changing recently, which makes identifying the
vulnerabilities difficult.

Even more unfortunately, when NPM changed the output format for
`npm audit --json` in npm v7, they removed many of the other useful
identifiers (`cves`, `cwe`, `github_advisory_id`). The only thing left
is the URL.

This patch allows vulnerabilities in the `.nsprc` file to be identified
by the URL instead of the sadly unstable id. This doesn't seem like a
really great option to me, since all the URLs changed from npmjs.com to
github.com a few months ago, and surely they'll change again. But it's
the closest thing we have to a stable id at the moment, so we'll go with
that.

See #60