### PR TITLE
Add support for non-numeric exception IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.7.1 (March 19, 2022)
+- [43380eb](https://github.com/jeemok/better-npm-audit/commit/43380eb54f6699ae121617603f8e3aaba1494321) Fixed unused exceptions handler
+
+## 3.7.0 (March 10, 2022)
+- [1871068](https://github.com/jeemok/better-npm-audit/commit/1871068fa3433b5fb4b93590540ccafc59dbfb38) Handles non numeric exception IDs
+
 ## 3.6.0 (February 23, 2022)
 
 - [#71](https://github.com/jeemok/better-npm-audit/pull/71) Added new option: ignore by module name

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The goal of this project is to help to reshape npm audit into the way the commun
 
 ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square) ![npm vulnerability](https://img.shields.io/snyk/vulnerabilities/npm/better-npm-audit?style=flat-square) ![GitHub issues](https://img.shields.io/github/issues/jeemok/better-npm-audit?style=flat-square) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/better-npm-audit?style=flat-square) ![Languages](https://img.shields.io/github/languages/top/jeemok/better-npm-audit?style=flat-square)
 
-## Supports both NPM version 6 and 7
+## NPM version 6 and 7
 
 NPM has upgraded to version 7 in late 2020 and has breaking changes on the `npm audit`. The output of npm audit has significantly changed both in the human-readable and `--json` output styles. We have added handling so it works properly in both npm versions.
 
@@ -71,13 +71,13 @@ npm run audit
 
 ## Options
 
-| Flag           | Short | Description                                                                    |
-| -------------- | ----- | ------------------------------------------------------------------------------ |
-| `--exclude`    | `-x`  | Exceptions or the vulnerabilities ID(s) to exclude
-| `--module-ignore` | `-m` | Names of modules to exclude                            |
-| `--level`      | `-l`  | The minimum audit level to validate; Same as the original `--audit-level` flag |
-| `--production` | `-p`  | Skip checking the `devDependencies`                                            |
-| `--registry`   | `-r`  | The npm registry url to use                                                    |
+| Flag              | Short | Description                                                                                           |
+| ----------------- | ----- | ----------------------------------------------------------------------------------------------------- |
+| `--exclude`       | `-x`  | Exceptions or the vulnerabilities ID(s) to exclude; the ID can be the numeric ID, CVE, CWE or GHSA ID |
+| `--module-ignore` | `-m`  | Names of modules to exclude                                                                           |
+| `--level`         | `-l`  | The minimum audit level to validate; Same as the original `--audit-level` flag                        |
+| `--production`    | `-p`  | Skip checking the `devDependencies`                                                                   |
+| `--registry`      | `-r`  | The npm registry url to use                                                                           |
 
 <br />
 
@@ -105,7 +105,7 @@ You may add a file `.nsprc` to your project root directory to manage the excepti
     "notes": "Ignored since we don't use xxx method"
   },
   "980": "Ignored since we don't use xxx method",
-  "Note": "Any non number key will not be accepted"
+  "GHSA-ww39-953v-wcq6": "GHSA ID is acceptable too"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The goal of this project is to help to reshape npm audit into the way the commun
 
 ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square) ![npm vulnerability](https://img.shields.io/snyk/vulnerabilities/npm/better-npm-audit?style=flat-square) ![GitHub issues](https://img.shields.io/github/issues/jeemok/better-npm-audit?style=flat-square) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/better-npm-audit?style=flat-square) ![Languages](https://img.shields.io/github/languages/top/jeemok/better-npm-audit?style=flat-square)
 
-## NPM version 6 and 7
+## NPM version 6 and 7, and 8
 
-NPM has upgraded to version 7 in late 2020 and has breaking changes on the `npm audit`. The output of npm audit has significantly changed both in the human-readable and `--json` output styles. We have added handling so it works properly in both npm versions.
+NPM has upgraded to version 7 in late 2020 and has breaking changes on the `npm audit`. The output of npm audit has significantly changed both in the human-readable and `--json` output styles. Even more unfortunately, when NPM changed the JSON output in npm v7, they removed many of the other useful identifiers (`cves`, `cwe`, `github_advisory_id`) and the only thing left is the URL. We are trying our best to handle each version and provide consistent functionality to all of them. Related docs on v6 and v7 changes:
 
 | Docs                       | Link                                                                                       |
 | -------------------------- | ------------------------------------------------------------------------------------------ |
@@ -104,8 +104,9 @@ You may add a file `.nsprc` to your project root directory to manage the excepti
     "active": false,
     "notes": "Ignored since we don't use xxx method"
   },
-  "980": "Ignored since we don't use xxx method",
-  "GHSA-ww39-953v-wcq6": "GHSA ID is acceptable too"
+  "CWE-471": "CWE ID is acceptable",
+  "GHSA-ww39-953v-wcq6": "GHSA ID is acceptable",
+  "https://npmjs.com/advisories/1213": "Full or partial URL is acceptable too"
 }
 ```
 
@@ -133,13 +134,10 @@ You can find the changelog [here](https://github.com/jeemok/better-npm-audit/blo
 
 <br />
 
-## Special mentions
+## Contributors
 
-- [@IanWright](https://github.com/IPWright83) for his solutions in improving the vulnerability validation for us to have the minimum-audit-level and production-mode flags.
+[Ian Wright](https://github.com/IPWright83), [Edwin Taylor](https://github.com/alertme-edwin), [Maarten Hus](https://github.com/MrHus), [Alex Burkowsky](https://github.com/alexburkowskypolysign), [David M. Lee](https://github.com/leedm777), [Kyle Clark](https://github.com/kyle-clark1824), [Guillermo Pincay](https://github.com/guillermaster), [Grzegorz Pawłowski](https://github.com/GrzesiekP), [CSLTech](https://github.com/CSLTech), [Paul Clarkin](https://github.com/paulclarkin), [mgdodge](https://github.com/mgdodge), [Ricky Sullivan](https://github.com/rickysullivan), [Sam Gregory](https://github.com/samgregory88), [Tristan WAGNER](https://github.com/tristanwagner)
 
-- [@EdwinTaylor](https://github.com/alertme-edwin) for all the bug reports and improvement suggestions.
-
-- [@MrHus](https://github.com/MrHus) for the logging of unused exceptions from the .nsprc file and -ignore flags. Courtesy of 42 BV.
 
 <br />
 

--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,7 @@ const program = new Command();
  * @param  {Array}  exceptionIds    List of vulnerability IDs to exclude
  * @param  {Array} modulesToIgnore   List of vulnerable modules to ignore in audit results
  */
-export function callback(auditCommand: string, auditLevel: AuditLevel, exceptionIds: number[], modulesToIgnore: string[]): void {
+export function callback(auditCommand: string, auditLevel: AuditLevel, exceptionIds: string[], modulesToIgnore: string[]): void {
   // Increase the default max buffer size (1 MB)
   const audit = exec(`${auditCommand} --json`, { maxBuffer: MAX_BUFFER_SIZE });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "better-npm-audit",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-npm-audit",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "author": "Jee Mok <jee.ict@hotmail.com>",
   "description": "Reshape into a better npm audit for the community and encourage more people to include security audit into their process.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "preaudit": "npm run build",
-    "audit": "node lib audit -x 1004946,1006897",
+    "audit": "node lib audit -x 1064843,1067245",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "lint": "eslint .",
     "qc": "npm run test && npm run lint",

--- a/src/handlers/handleFinish.ts
+++ b/src/handlers/handleFinish.ts
@@ -10,7 +10,7 @@ import { processAuditJson } from '../utils/vulnerability';
  * @param  {Array} modulesToIgnore   List of vulnerable modules to ignore in audit results
  * @return {undefined}
  */
-export default function handleFinish(jsonBuffer: string, auditLevel: AuditLevel, exceptionIds: number[], modulesToIgnore: string[]): void {
+export default function handleFinish(jsonBuffer: string, auditLevel: AuditLevel, exceptionIds: string[], modulesToIgnore: string[]): void {
   const { unhandledIds, vulnerabilityIds, vulnerabilityModules, report, failed } = processAuditJson(
     jsonBuffer,
     auditLevel,

--- a/src/handlers/handleInput.ts
+++ b/src/handlers/handleInput.ts
@@ -1,6 +1,5 @@
 import get from 'lodash.get';
 import { AuditLevel, CommandOptions } from 'src/types';
-import { isWholeNumber } from '../utils/common';
 import { readFile } from '../utils/file';
 import { getExceptionsIds } from '../utils/vulnerability';
 
@@ -9,7 +8,7 @@ import { getExceptionsIds } from '../utils/vulnerability';
  * @param  {Object} options     User's command options or flags
  * @param  {Function} fn        The function to handle the inputs
  */
-export default function handleInput(options: CommandOptions, fn: (T1: string, T2: AuditLevel, T3: number[], T4: string[]) => void): void {
+export default function handleInput(options: CommandOptions, fn: (T1: string, T2: AuditLevel, T3: string[], T4: string[]) => void): void {
   // Generate NPM Audit command
   const auditCommand: string = [
     'npm audit',
@@ -26,8 +25,11 @@ export default function handleInput(options: CommandOptions, fn: (T1: string, T2
 
   // Get the exceptions
   const nsprc = readFile('.nsprc');
-  const cmdExceptions: number[] = get(options, 'exclude', '').split(',').filter(isWholeNumber).map(Number);
-  const exceptionIds: number[] = getExceptionsIds(nsprc, cmdExceptions);
+  const cmdExceptions: string[] = get(options, 'exclude', '')
+    .split(',')
+    .map((each) => each.trim())
+    .filter((each) => each !== '');
+  const exceptionIds: string[] = getExceptionsIds(nsprc, cmdExceptions);
   const cmdModuleIgnore: string[] = get(options, 'moduleIgnore', '').split(',');
 
   fn(auditCommand, auditLevel, exceptionIds, cmdModuleIgnore);

--- a/src/types/general.d.ts
+++ b/src/types/general.d.ts
@@ -18,8 +18,9 @@ export interface v6Advisories {
 }
 
 export interface v6Advisory {
-  readonly id: string;
+  readonly id: number;
   readonly cves: string[];
+  readonly cwe: string;
   // eslint-disable-next-line camelcase
   readonly module_name: string;
   readonly title: string;
@@ -52,14 +53,14 @@ export interface v7VulnerabilityVia {
 }
 
 export interface ProcessedResult {
-  readonly unhandledIds: number[];
-  readonly vulnerabilityIds: number[];
+  readonly unhandledIds: string[];
+  readonly vulnerabilityIds: string[];
   readonly vulnerabilityModules: string[];
   readonly report: string[][];
   readonly failed?: boolean;
 }
 
 export interface ProcessedReport {
-  readonly exceptionIds: number[];
+  readonly exceptionIds: string[];
   readonly report: string[][];
 }

--- a/src/types/general.d.ts
+++ b/src/types/general.d.ts
@@ -54,10 +54,12 @@ export interface v7VulnerabilityVia {
 
 export interface ProcessedResult {
   readonly unhandledIds: string[];
-  readonly vulnerabilityIds: string[];
-  readonly vulnerabilityModules: string[];
+  readonly vulnerabilityIds: string[]; // Currently unused, but very valuable info so leave it here for now
+  readonly vulnerabilityModules: string[]; // Currently unused, but very valuable info so leave it here for now
   readonly report: string[][];
   readonly failed?: boolean;
+  unusedExceptionIds: string[];
+  unusedExceptionModules: string[];
 }
 
 export interface ProcessedReport {

--- a/src/types/general.d.ts
+++ b/src/types/general.d.ts
@@ -19,6 +19,7 @@ export interface v6Advisories {
 
 export interface v6Advisory {
   readonly id: string;
+  readonly cves: string[];
   // eslint-disable-next-line camelcase
   readonly module_name: string;
   readonly title: string;

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,3 +1,4 @@
+// TODO: This might be unused
 /**
  * @param  {String | Number | Null | Boolean} value     The input number
  * @return {Boolean}                                    Returns true if the input is a whole number

--- a/src/utils/vulnerability.ts
+++ b/src/utils/vulnerability.ts
@@ -43,6 +43,50 @@ export function mapLevelToNumber(auditLevel: AuditLevel | string): AuditNumber {
 }
 
 /**
+ * Validate if the vulnerability should be excepted
+ * @param {Object}  vulnerability   NPM v6 audit report's vulnerability
+ * @param {Array}   exceptionIds    Exception IDs
+ * @return {Boolean}                If this vulnerability should be ignored
+ */
+export function validateV6Vulnerability(vulnerability: v6Advisory, exceptionIds: string[]): boolean {
+  // check if ID matches
+  if (exceptionIds.some((id) => id === String(vulnerability.id))) {
+    return true;
+  }
+  // check if any of the CVEs matches
+  if (exceptionIds.some((id) => Array.isArray(vulnerability.cves) && vulnerability.cves.includes(id))) {
+    return true;
+  }
+  // check if the CWE matches
+  if (exceptionIds.some((id) => vulnerability.cwe === id)) {
+    return true;
+  }
+  // check if the URL matches
+  if (exceptionIds.some((id) => vulnerability.url && vulnerability.url.includes(id))) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Validate if the vulnerability should be excepted
+ * @param {Object}  vulnerability   NPM v7 audit report's vulnerability
+ * @param {Array}   exceptionIds    Exception IDs
+ * @return {Boolean}                If this vulnerability should be ignored
+ */
+export function validateV7Vulnerability(vulnerability: v7VulnerabilityVia, exceptionIds: string[]): boolean {
+  // check if ID matches
+  if (exceptionIds.some((id) => id === String(vulnerability.source))) {
+    return true;
+  }
+  // check if the URL matches
+  if (exceptionIds.some((id) => vulnerability.url && vulnerability.url.includes(id))) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Analyze the JSON string buffer
  * @param  {String} jsonBuffer      NPM Audit JSON string buffer
  * @param  {String} auditLevel      User's target audit level
@@ -53,7 +97,7 @@ export function mapLevelToNumber(auditLevel: AuditLevel | string): AuditNumber {
 export function processAuditJson(
   jsonBuffer = '',
   auditLevel: AuditLevel = 'info',
-  exceptionIds: number[] = [],
+  exceptionIds: string[] = [],
   modulesToIgnore: string[] = [],
 ): ProcessedResult {
   if (!isJsonString(jsonBuffer)) {
@@ -76,21 +120,12 @@ export function processAuditJson(
     return Object.values(advisories).reduce(
       (acc: ProcessedResult, cur: v6Advisory) => {
         const shouldAudit = mapLevelToNumber(cur.severity) >= mapLevelToNumber(auditLevel);
-        let isExcepted: boolean = false;
-
-        if (cur.id && exceptionIds.includes(Number(cur.id)) || // NPM v6 contains 'id's to use
-            (cur.cves && exceptionIds.filter(id => cur.cves.includes(id)).length > 0) || // NPM v6 can also have an array of cve id's
-            (cur.via && cur.via[0].source && exceptionIds.includes(Number(cur.via[0].source))) || //auditReportVersion: 2. Check via.source for id
-            (cur.via && cur.via[0].url && exceptionIds.filter(id => cur.via[0].url.contains(id)).length > 0 )) //auditReportVersion: 2. Check via.url for github id
-        {
-            isExcepted = true;
-        }
-
+        const isExcepted = validateV6Vulnerability(cur, exceptionIds);
         const isIgnoredModule = modulesToIgnore.includes(cur.module_name);
 
         // Record this vulnerability into the report, and highlight it using yellow color if it's new
         acc.report.push([
-          color(cur.id, isExcepted || isIgnoredModule ? '' : 'yellow'),
+          color(cur.id.toString(), isExcepted || isIgnoredModule ? '' : 'yellow'),
           color(cur.module_name, isExcepted || isIgnoredModule ? '' : 'yellow'),
           color(cur.title, isExcepted || isIgnoredModule ? '' : 'yellow'),
           color(
@@ -105,14 +140,14 @@ export function processAuditJson(
           isExcepted || isIgnoredModule ? 'y' : color('n', 'yellow'),
         ]);
 
-        acc.vulnerabilityIds.push(Number(cur.id));
+        acc.vulnerabilityIds.push(cur.id.toString());
         if (!acc.vulnerabilityModules.includes(cur.module_name)) {
           acc.vulnerabilityModules.push(cur.module_name);
         }
 
         // Found unhandled vulnerabilities
         if (shouldAudit && !isExcepted && !isIgnoredModule) {
-          acc.unhandledIds.push(Number(cur.id));
+          acc.unhandledIds.push(cur.id.toString());
         }
 
         return acc;
@@ -133,7 +168,7 @@ export function processAuditJson(
         // Inside `via` array, its either the related module name or the vulnerability source object.
         get(cur, 'via', []).forEach((vul: v7VulnerabilityVia | string) => {
           // The vulnerability ID is labeled as `source`
-          const id = get(vul, 'source', '');
+          const id = get(vul, 'source');
           const moduleName = get(vul, 'name', '');
 
           // Let's skip if ID is a string (module name), and only focus on the root vulnerabilities
@@ -142,7 +177,7 @@ export function processAuditJson(
           }
 
           const shouldAudit = mapLevelToNumber(vul.severity) >= mapLevelToNumber(auditLevel);
-          const isExcepted = exceptionIds.includes(id);
+          const isExcepted = validateV7Vulnerability(vul, exceptionIds);
           const isIgnoredModule = modulesToIgnore.includes(moduleName);
 
           // Record this vulnerability into the report, and highlight it using yellow color if it's new
@@ -159,7 +194,7 @@ export function processAuditJson(
             isExcepted || isIgnoredModule ? 'y' : color('n', 'yellow'),
           ]);
 
-          acc.vulnerabilityIds.push(id);
+          acc.vulnerabilityIds.push(String(id));
           if (!acc.vulnerabilityModules.includes(moduleName)) {
             acc.vulnerabilityModules.push(moduleName);
           }
@@ -195,7 +230,7 @@ export function processAuditJson(
  * @param  {Array}            cmdExceptions   Exceptions passed in via command line
  * @return {Array}                            List of found vulnerabilities
  */
-export function getExceptionsIds(nsprc?: NsprcFile | boolean, cmdExceptions: number[] = []): number[] {
+export function getExceptionsIds(nsprc?: NsprcFile | boolean, cmdExceptions: string[] = []): string[] {
   // If file does not exists
   if (!nsprc || typeof nsprc !== 'object') {
     // If there are exceptions passed in from command line
@@ -222,11 +257,9 @@ export function getExceptionsIds(nsprc?: NsprcFile | boolean, cmdExceptions: num
  * @param  {Array}  cmdExceptions   Exceptions passed in via command line
  * @return {Object}                 Processed vulnerabilities details
  */
-export function processExceptions(nsprc: NsprcFile, cmdExceptions: number[] = []): ProcessedReport {
+export function processExceptions(nsprc: NsprcFile, cmdExceptions: string[] = []): ProcessedReport {
   return Object.entries(nsprc).reduce(
     (acc: ProcessedReport, [id, details]: [string, string | NsprcConfigs]) => {
-      const numberId = Number(id);
-      const isValidId = !isNaN(numberId);
       const isActive = Boolean(get(details, 'active', true)); // default to true
       const notes = typeof details === 'string' ? details : get(details, 'notes', '');
       const { valid, expired, years } = analyzeExpiry(get(details, 'expiry'));
@@ -235,7 +268,7 @@ export function processExceptions(nsprc: NsprcFile, cmdExceptions: number[] = []
       let status = color('active', 'green');
       if (expired) {
         status = color('expired', 'red');
-      } else if (!isValidId || !valid) {
+      } else if (!valid) {
         status = color('invalid', 'red');
       } else if (!isActive) {
         status = color('inactive', 'yellow');
@@ -252,8 +285,8 @@ export function processExceptions(nsprc: NsprcFile, cmdExceptions: number[] = []
 
       acc.report.push([id, status, expiryDate, notes]);
 
-      if (isValidId && isActive && !expired) {
-        acc.exceptionIds.push(numberId);
+      if (isActive && !expired) {
+        acc.exceptionIds.push(id);
       }
 
       return acc;

--- a/src/utils/vulnerability.ts
+++ b/src/utils/vulnerability.ts
@@ -46,26 +46,37 @@ export function mapLevelToNumber(auditLevel: AuditLevel | string): AuditNumber {
  * Validate if the vulnerability should be excepted
  * @param {Object}  vulnerability   NPM v6 audit report's vulnerability
  * @param {Array}   exceptionIds    Exception IDs
- * @return {Boolean}                If this vulnerability should be ignored
+ * @return {Object}                 Validation result
  */
-export function validateV6Vulnerability(vulnerability: v6Advisory, exceptionIds: string[]): boolean {
-  // check if ID matches
-  if (exceptionIds.some((id) => id === String(vulnerability.id))) {
-    return true;
-  }
-  // check if any of the CVEs matches
-  if (exceptionIds.some((id) => Array.isArray(vulnerability.cves) && vulnerability.cves.includes(id))) {
-    return true;
-  }
-  // check if the CWE matches
-  if (exceptionIds.some((id) => vulnerability.cwe === id)) {
-    return true;
-  }
-  // check if the URL matches
-  if (exceptionIds.some((id) => vulnerability.url && vulnerability.url.includes(id))) {
-    return true;
-  }
-  return false;
+export function validateV6Vulnerability(
+  vulnerability: v6Advisory,
+  exceptionIds: string[],
+): { isExcepted: boolean; usedExceptionKey: string } {
+  return exceptionIds.reduce(
+    (acc: { isExcepted: boolean; usedExceptionKey: string }, id) => {
+      // check if ID matches
+      if (id === String(vulnerability.id)) {
+        return { isExcepted: true, usedExceptionKey: id };
+      }
+      // check if any of the CVEs matches
+      if (Array.isArray(vulnerability.cves) && vulnerability.cves.includes(id)) {
+        return { isExcepted: true, usedExceptionKey: id };
+      }
+      // check if the CWE matches
+      if (vulnerability.cwe === id) {
+        return { isExcepted: true, usedExceptionKey: id };
+      }
+      // check if the URL matches
+      if (vulnerability.url && vulnerability.url.includes(id)) {
+        return { isExcepted: true, usedExceptionKey: id };
+      }
+      return acc;
+    },
+    {
+      isExcepted: false,
+      usedExceptionKey: '',
+    },
+  );
 }
 
 /**
@@ -74,37 +85,50 @@ export function validateV6Vulnerability(vulnerability: v6Advisory, exceptionIds:
  * @param {Array}   exceptionIds    Exception IDs
  * @return {Boolean}                If this vulnerability should be ignored
  */
-export function validateV7Vulnerability(vulnerability: v7VulnerabilityVia, exceptionIds: string[]): boolean {
-  // check if ID matches
-  if (exceptionIds.some((id) => id === String(vulnerability.source))) {
-    return true;
-  }
-  // check if the URL matches
-  if (exceptionIds.some((id) => vulnerability.url && vulnerability.url.includes(id))) {
-    return true;
-  }
-  return false;
+export function validateV7Vulnerability(
+  vulnerability: v7VulnerabilityVia,
+  exceptionIds: string[],
+): { isExcepted: boolean; usedExceptionKey: string } {
+  return exceptionIds.reduce(
+    (acc: { isExcepted: boolean; usedExceptionKey: string }, id) => {
+      // check if ID matches
+      if (id === String(vulnerability.source)) {
+        return { isExcepted: true, usedExceptionKey: id };
+      }
+      // check if the URL matches
+      if (vulnerability.url && vulnerability.url.includes(id)) {
+        return { isExcepted: true, usedExceptionKey: id };
+      }
+      return acc;
+    },
+    {
+      isExcepted: false,
+      usedExceptionKey: '',
+    },
+  );
 }
 
 /**
  * Analyze the JSON string buffer
  * @param  {String} jsonBuffer      NPM Audit JSON string buffer
  * @param  {String} auditLevel      User's target audit level
- * @param  {Array}  exceptionIds    User's exception IDs
- * @param  {Array} modulesToIgnore  Users modules to ignore
+ * @param  {Array} exceptionIds     Exception IDs (ID to be ignored)
+ * @param  {Array} exceptionModules Exception modules (modules to be ignored)
  * @return {Object}                 Processed vulnerabilities details
  */
 export function processAuditJson(
   jsonBuffer = '',
   auditLevel: AuditLevel = 'info',
   exceptionIds: string[] = [],
-  modulesToIgnore: string[] = [],
+  exceptionModules: string[] = [],
 ): ProcessedResult {
   if (!isJsonString(jsonBuffer)) {
     return {
       unhandledIds: [],
       vulnerabilityIds: [],
       vulnerabilityModules: [],
+      unusedExceptionIds: exceptionIds,
+      unusedExceptionModules: exceptionModules,
       report: [],
       failed: true,
     };
@@ -120,24 +144,33 @@ export function processAuditJson(
     return Object.values(advisories).reduce(
       (acc: ProcessedResult, cur: v6Advisory) => {
         const shouldAudit = mapLevelToNumber(cur.severity) >= mapLevelToNumber(auditLevel);
-        const isExcepted = validateV6Vulnerability(cur, exceptionIds);
-        const isIgnoredModule = modulesToIgnore.includes(cur.module_name);
+        const { isExcepted: isIdExcepted, usedExceptionKey } = validateV6Vulnerability(cur, exceptionIds);
+        const isModuleExcepted = exceptionModules.includes(cur.module_name);
+        const isExcepted = isIdExcepted || isModuleExcepted;
+
+        // Record used exception ID/module
+        if (isIdExcepted) {
+          acc.unusedExceptionIds = acc.unusedExceptionIds.filter((id) => id !== usedExceptionKey);
+        }
+        if (isModuleExcepted) {
+          acc.unusedExceptionModules = acc.unusedExceptionModules.filter((module) => module !== cur.module_name);
+        }
 
         // Record this vulnerability into the report, and highlight it using yellow color if it's new
         acc.report.push([
-          color(cur.id.toString(), isExcepted || isIgnoredModule ? '' : 'yellow'),
-          color(cur.module_name, isExcepted || isIgnoredModule ? '' : 'yellow'),
-          color(cur.title, isExcepted || isIgnoredModule ? '' : 'yellow'),
+          color(cur.id.toString(), isExcepted ? '' : 'yellow'),
+          color(cur.module_name, isExcepted ? '' : 'yellow'),
+          color(cur.title, isExcepted ? '' : 'yellow'),
           color(
             trimArray(
               cur.findings.reduce((a, c) => [...a, ...c.paths] as [], []),
               MAX_PATHS_SIZE,
             ).join('\n'),
-            isExcepted || isIgnoredModule ? '' : 'yellow',
+            isExcepted ? '' : 'yellow',
           ),
-          color(cur.severity, isExcepted || isIgnoredModule ? '' : 'yellow', getSeverityBgColor(cur.severity)),
-          color(cur.url, isExcepted || isIgnoredModule ? '' : 'yellow'),
-          isExcepted || isIgnoredModule ? 'y' : color('n', 'yellow'),
+          color(cur.severity, isExcepted ? '' : 'yellow', getSeverityBgColor(cur.severity)),
+          color(cur.url, isExcepted ? '' : 'yellow'),
+          isExcepted ? 'y' : color('n', 'yellow'),
         ]);
 
         acc.vulnerabilityIds.push(cur.id.toString());
@@ -146,7 +179,7 @@ export function processAuditJson(
         }
 
         // Found unhandled vulnerabilities
-        if (shouldAudit && !isExcepted && !isIgnoredModule) {
+        if (shouldAudit && !isExcepted) {
           acc.unhandledIds.push(cur.id.toString());
         }
 
@@ -156,6 +189,8 @@ export function processAuditJson(
         unhandledIds: [],
         vulnerabilityIds: [],
         vulnerabilityModules: [],
+        unusedExceptionIds: exceptionIds,
+        unusedExceptionModules: exceptionModules,
         report: [],
       },
     );
@@ -177,21 +212,27 @@ export function processAuditJson(
           }
 
           const shouldAudit = mapLevelToNumber(vul.severity) >= mapLevelToNumber(auditLevel);
-          const isExcepted = validateV7Vulnerability(vul, exceptionIds);
-          const isIgnoredModule = modulesToIgnore.includes(moduleName);
+          const { isExcepted: isIdExcepted, usedExceptionKey } = validateV7Vulnerability(vul, exceptionIds);
+          const isModuleExcepted = exceptionModules.includes(moduleName);
+          const isExcepted = isIdExcepted || isModuleExcepted;
+
+          // Record used exception ID/module
+          if (isIdExcepted) {
+            acc.unusedExceptionIds = acc.unusedExceptionIds.filter((id) => id !== usedExceptionKey);
+          }
+          if (isModuleExcepted) {
+            acc.unusedExceptionModules = acc.unusedExceptionModules.filter((module) => module !== moduleName);
+          }
 
           // Record this vulnerability into the report, and highlight it using yellow color if it's new
           acc.report.push([
-            color(String(id), isExcepted || isIgnoredModule ? '' : 'yellow'),
-            color(vul.name, isExcepted || isIgnoredModule ? '' : 'yellow'),
-            color(vul.title, isExcepted || isIgnoredModule ? '' : 'yellow'),
-            color(
-              trimArray(get(cur, 'nodes', []).map(shortenNodePath), MAX_PATHS_SIZE).join('\n'),
-              isExcepted || isIgnoredModule ? '' : 'yellow',
-            ),
-            color(vul.severity, isExcepted || isIgnoredModule ? '' : 'yellow', getSeverityBgColor(vul.severity)),
-            color(vul.url, isExcepted || isIgnoredModule ? '' : 'yellow'),
-            isExcepted || isIgnoredModule ? 'y' : color('n', 'yellow'),
+            color(String(id), isExcepted ? '' : 'yellow'),
+            color(vul.name, isExcepted ? '' : 'yellow'),
+            color(vul.title, isExcepted ? '' : 'yellow'),
+            color(trimArray(get(cur, 'nodes', []).map(shortenNodePath), MAX_PATHS_SIZE).join('\n'), isExcepted ? '' : 'yellow'),
+            color(vul.severity, isExcepted ? '' : 'yellow', getSeverityBgColor(vul.severity)),
+            color(vul.url, isExcepted ? '' : 'yellow'),
+            isExcepted ? 'y' : color('n', 'yellow'),
           ]);
 
           acc.vulnerabilityIds.push(String(id));
@@ -200,8 +241,8 @@ export function processAuditJson(
           }
 
           // Found unhandled vulnerabilities
-          if (shouldAudit && !isExcepted && !isIgnoredModule) {
-            acc.unhandledIds.push(id);
+          if (shouldAudit && !isExcepted) {
+            acc.unhandledIds.push(String(id));
           }
         });
 
@@ -211,6 +252,8 @@ export function processAuditJson(
         unhandledIds: [],
         vulnerabilityIds: [],
         vulnerabilityModules: [],
+        unusedExceptionIds: exceptionIds,
+        unusedExceptionModules: exceptionModules,
         report: [],
       },
     );
@@ -219,6 +262,8 @@ export function processAuditJson(
     unhandledIds: [],
     vulnerabilityIds: [],
     vulnerabilityModules: [],
+    unusedExceptionIds: exceptionIds,
+    unusedExceptionModules: exceptionModules,
     report: [],
     failed: true,
   };
@@ -296,4 +341,32 @@ export function processExceptions(nsprc: NsprcFile, cmdExceptions: string[] = []
       report: cmdExceptions.map((id) => [String(id), color('active', 'green'), '', '']),
     },
   );
+}
+
+/**
+ * Handle unused exceptions from user: console log them
+ * @param {Array} unusedExceptionIds      List of unused exception IDs
+ * @param {Array} unusedExceptionModules  List of unused exception module names
+ */
+export function handleUnusedExceptions(unusedExceptionIds: string[], unusedExceptionModules: string[]): void {
+  const message = [
+    unusedExceptionIds.length &&
+      `${
+        unusedExceptionIds.length
+      } of the excluded vulnerabilities did not match any of the found vulnerabilities: ${unusedExceptionIds.join(', ')}.`,
+    unusedExceptionIds.length &&
+      `${unusedExceptionIds.length > 1 ? 'They' : 'It'} can be removed from the .nsprc file or --exclude -x flags.`,
+    unusedExceptionModules.length &&
+      `${
+        unusedExceptionModules.length
+      } of the ignored modules did not match any of the found vulnerabilities: ${unusedExceptionModules.join(', ')}.`,
+    unusedExceptionModules.length &&
+      `${unusedExceptionModules.length > 1 ? 'They' : 'It'} can be removed from the --module-ignore -m flags.`,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  if (message) {
+    console.warn(message);
+  }
 }

--- a/src/utils/vulnerability.ts
+++ b/src/utils/vulnerability.ts
@@ -76,7 +76,16 @@ export function processAuditJson(
     return Object.values(advisories).reduce(
       (acc: ProcessedResult, cur: v6Advisory) => {
         const shouldAudit = mapLevelToNumber(cur.severity) >= mapLevelToNumber(auditLevel);
-        const isExcepted = exceptionIds.includes(Number(cur.id));
+        let isExcepted: boolean = false;
+
+        if (cur.id && exceptionIds.includes(Number(cur.id)) || // NPM v6 contains 'id's to use
+            (cur.cves && exceptionIds.filter(id => cur.cves.includes(id)).length > 0) || // NPM v6 can also have an array of cve id's
+            (cur.via && cur.via[0].source && exceptionIds.includes(Number(cur.via[0].source))) || //auditReportVersion: 2. Check via.source for id
+            (cur.via && cur.via[0].url && exceptionIds.filter(id => cur.via[0].url.contains(id)).length > 0 )) //auditReportVersion: 2. Check via.url for github id
+        {
+            isExcepted = true;
+        }
+
         const isIgnoredModule = modulesToIgnore.includes(cur.module_name);
 
         // Record this vulnerability into the report, and highlight it using yellow color if it's new

--- a/test/__mocks__/exception-table-data.json
+++ b/test/__mocks__/exception-table-data.json
@@ -84,9 +84,15 @@
     "Unused"
   ],
   [
-    "Note",
-    "\u001b[31minvalid\u001b[0m",
+    "CWE-126",
+    "\u001b[32mactive\u001b[0m",
     "",
-    "personal note"
+    "CWE ID"
+  ],
+  [
+    "GHSA-ww39-953v-wcq6",
+    "\u001b[32mactive\u001b[0m",
+    "",
+    "GHSA ID"
   ]
 ]

--- a/test/__mocks__/nsprc.json
+++ b/test/__mocks__/nsprc.json
@@ -35,5 +35,6 @@
         "expiry": "2030-01-01"
     },
     "2100": "Unused",
-    "Note": "personal note"
+    "CWE-126": "CWE ID",
+    "GHSA-ww39-953v-wcq6": "GHSA ID"
 }

--- a/test/__mocks__/v8-json-buffer.json
+++ b/test/__mocks__/v8-json-buffer.json
@@ -1,0 +1,429 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {
+    "ansi-regex": {
+      "name": "ansi-regex",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1004946,
+          "name": "ansi-regex",
+          "dependency": "ansi-regex",
+          "title": " Inefficient Regular Expression Complexity in chalk/ansi-regex",
+          "url": "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
+          "severity": "moderate",
+          "range": ">2.1.1 <5.0.1"
+        }
+      ],
+      "effects": ["strip-ansi"],
+      "range": ">2.1.1 <5.0.1",
+      "nodes": ["node_modules/inquirer/node_modules/ansi-regex", "node_modules/nsp/node_modules/ansi-regex"],
+      "fixAvailable": true
+    },
+    "anymatch": {
+      "name": "anymatch",
+      "severity": "low",
+      "isDirect": false,
+      "via": ["micromatch"],
+      "effects": ["chokidar"],
+      "range": "1.2.0 - 1.3.2",
+      "nodes": ["node_modules/anymatch"],
+      "fixAvailable": false
+    },
+    "babel-cli": {
+      "name": "babel-cli",
+      "severity": "high",
+      "isDirect": true,
+      "via": ["chokidar"],
+      "effects": [],
+      "range": "",
+      "nodes": ["node_modules/babel-cli"],
+      "fixAvailable": false
+    },
+    "braces": {
+      "name": "braces",
+      "severity": "low",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1006342,
+          "name": "braces",
+          "dependency": "braces",
+          "title": "Regular Expression Denial of Service in braces",
+          "url": "https://github.com/advisories/GHSA-g95f-p29q-9xw4",
+          "severity": "low",
+          "range": "<2.3.1"
+        }
+      ],
+      "effects": ["micromatch"],
+      "range": "<2.3.1",
+      "nodes": ["node_modules/braces"],
+      "fixAvailable": false
+    },
+    "chokidar": {
+      "name": "chokidar",
+      "severity": "high",
+      "isDirect": false,
+      "via": ["anymatch", "glob-parent"],
+      "effects": ["babel-cli", "glob-watcher"],
+      "range": "1.0.0-rc1 - 2.1.8",
+      "nodes": ["node_modules/chokidar", "node_modules/glob-watcher/node_modules/chokidar"],
+      "fixAvailable": false
+    },
+    "cli-table2": {
+      "name": "cli-table2",
+      "severity": "high",
+      "isDirect": false,
+      "via": ["lodash"],
+      "effects": ["nsp"],
+      "range": "",
+      "nodes": ["node_modules/cli-table2"],
+      "fixAvailable": {
+        "name": "nsp",
+        "version": "2.8.1",
+        "isSemVerMajor": true
+      }
+    },
+    "glob-base": {
+      "name": "glob-base",
+      "severity": "high",
+      "isDirect": false,
+      "via": ["glob-parent"],
+      "effects": ["parse-glob"],
+      "range": "",
+      "nodes": ["node_modules/glob-base"],
+      "fixAvailable": false
+    },
+    "glob-parent": {
+      "name": "glob-parent",
+      "severity": "high",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1005154,
+          "name": "glob-parent",
+          "dependency": "glob-parent",
+          "title": "Regular expression denial of service",
+          "url": "https://github.com/advisories/GHSA-ww39-953v-wcq6",
+          "severity": "high",
+          "range": "<5.1.2"
+        }
+      ],
+      "effects": ["chokidar", "glob-base", "glob-stream"],
+      "range": "<5.1.2",
+      "nodes": [
+        "node_modules/glob-parent",
+        "node_modules/glob-stream/node_modules/glob-parent",
+        "node_modules/glob-watcher/node_modules/glob-parent"
+      ],
+      "fixAvailable": false
+    },
+    "glob-stream": {
+      "name": "glob-stream",
+      "severity": "high",
+      "isDirect": false,
+      "via": ["glob-parent"],
+      "effects": ["vinyl-fs"],
+      "range": "5.3.0 - 6.1.0",
+      "nodes": ["node_modules/glob-stream"],
+      "fixAvailable": {
+        "name": "gulp",
+        "version": "3.9.1",
+        "isSemVerMajor": true
+      }
+    },
+    "glob-watcher": {
+      "name": "glob-watcher",
+      "severity": "high",
+      "isDirect": false,
+      "via": ["chokidar"],
+      "effects": [],
+      "range": ">=3.0.0",
+      "nodes": ["node_modules/glob-watcher"],
+      "fixAvailable": true
+    },
+    "gulp": {
+      "name": "gulp",
+      "severity": "high",
+      "isDirect": true,
+      "via": ["vinyl-fs"],
+      "effects": [],
+      "range": ">=4.0.0",
+      "nodes": ["node_modules/gulp"],
+      "fixAvailable": {
+        "name": "gulp",
+        "version": "3.9.1",
+        "isSemVerMajor": true
+      }
+    },
+    "inquirer": {
+      "name": "inquirer",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": ["string-width", "strip-ansi"],
+      "effects": [],
+      "range": "3.2.0 - 7.0.4",
+      "nodes": ["node_modules/inquirer"],
+      "fixAvailable": true
+    },
+    "isparta": {
+      "name": "isparta",
+      "severity": "high",
+      "isDirect": true,
+      "via": ["nomnomnomnom"],
+      "effects": [],
+      "range": ">=3.1.0",
+      "nodes": ["node_modules/isparta"],
+      "fixAvailable": {
+        "name": "isparta",
+        "version": "3.0.4",
+        "isSemVerMajor": true
+      }
+    },
+    "lodash": {
+      "name": "lodash",
+      "severity": "critical",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1005365,
+          "name": "lodash",
+          "dependency": "lodash",
+          "title": "Command Injection in lodash",
+          "url": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
+          "severity": "high",
+          "range": "<4.17.21"
+        },
+        {
+          "source": 1006094,
+          "name": "lodash",
+          "dependency": "lodash",
+          "title": "Prototype Pollution in lodash",
+          "url": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
+          "severity": "high",
+          "range": "<4.17.19"
+        },
+        {
+          "source": 1006231,
+          "name": "lodash",
+          "dependency": "lodash",
+          "title": "Prototype Pollution in lodash",
+          "url": "https://github.com/advisories/GHSA-jf85-cpcp-j695",
+          "severity": "critical",
+          "range": "<4.17.12"
+        },
+        {
+          "source": 1006298,
+          "name": "lodash",
+          "dependency": "lodash",
+          "title": "Prototype pollution in lodash",
+          "url": "https://github.com/advisories/GHSA-x5rq-j2xg-h7qm",
+          "severity": "moderate",
+          "range": "<4.17.11"
+        },
+        {
+          "source": 1006517,
+          "name": "lodash",
+          "dependency": "lodash",
+          "title": "Prototype Pollution in lodash",
+          "url": "https://github.com/advisories/GHSA-fvqr-27wr-82fm",
+          "severity": "low",
+          "range": "<4.17.5"
+        }
+      ],
+      "effects": ["cli-table2"],
+      "range": "<=4.17.20",
+      "nodes": ["node_modules/cli-table2/node_modules/lodash"],
+      "fixAvailable": {
+        "name": "nsp",
+        "version": "2.8.1",
+        "isSemVerMajor": true
+      }
+    },
+    "mem": {
+      "name": "mem",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1006311,
+          "name": "mem",
+          "dependency": "mem",
+          "title": "Denial of Service in mem",
+          "url": "https://github.com/advisories/GHSA-4xcv-9jjx-gfj3",
+          "severity": "moderate",
+          "range": "<4.0.0"
+        }
+      ],
+      "effects": ["os-locale"],
+      "range": "<4.0.0",
+      "nodes": ["node_modules/mem"],
+      "fixAvailable": true
+    },
+    "micromatch": {
+      "name": "micromatch",
+      "severity": "high",
+      "isDirect": false,
+      "via": ["braces", "parse-glob"],
+      "effects": ["anymatch"],
+      "range": "0.2.0 - 2.3.11",
+      "nodes": ["node_modules/micromatch"],
+      "fixAvailable": false
+    },
+    "nomnomnomnom": {
+      "name": "nomnomnomnom",
+      "severity": "high",
+      "isDirect": false,
+      "via": ["underscore"],
+      "effects": ["isparta"],
+      "range": "",
+      "nodes": ["node_modules/nomnomnomnom"],
+      "fixAvailable": {
+        "name": "isparta",
+        "version": "3.0.4",
+        "isSemVerMajor": true
+      }
+    },
+    "nsp": {
+      "name": "nsp",
+      "severity": "high",
+      "isDirect": true,
+      "via": ["cli-table2"],
+      "effects": [],
+      "range": ">=3.0.0",
+      "nodes": ["node_modules/nsp"],
+      "fixAvailable": {
+        "name": "nsp",
+        "version": "2.8.1",
+        "isSemVerMajor": true
+      }
+    },
+    "os-locale": {
+      "name": "os-locale",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": ["mem"],
+      "effects": ["yargs"],
+      "range": "2.0.0 - 3.0.0",
+      "nodes": ["node_modules/nsp/node_modules/os-locale"],
+      "fixAvailable": true
+    },
+    "parse-glob": {
+      "name": "parse-glob",
+      "severity": "high",
+      "isDirect": false,
+      "via": ["glob-base"],
+      "effects": ["micromatch"],
+      "range": ">=2.1.0",
+      "nodes": ["node_modules/parse-glob"],
+      "fixAvailable": false
+    },
+    "string-width": {
+      "name": "string-width",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": ["strip-ansi"],
+      "effects": ["inquirer"],
+      "range": "2.1.0 - 4.1.0",
+      "nodes": ["node_modules/inquirer/node_modules/string-width", "node_modules/nsp/node_modules/string-width"],
+      "fixAvailable": true
+    },
+    "strip-ansi": {
+      "name": "strip-ansi",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": ["ansi-regex"],
+      "effects": ["inquirer", "string-width"],
+      "range": "4.0.0 - 5.2.0",
+      "nodes": ["node_modules/inquirer/node_modules/strip-ansi", "node_modules/nsp/node_modules/strip-ansi"],
+      "fixAvailable": true
+    },
+    "underscore": {
+      "name": "underscore",
+      "severity": "high",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1005367,
+          "name": "underscore",
+          "dependency": "underscore",
+          "title": "Arbitrary Code Execution in underscore",
+          "url": "https://github.com/advisories/GHSA-cf4h-3jhx-xvhq",
+          "severity": "high",
+          "range": ">=1.3.2 <1.12.1"
+        }
+      ],
+      "effects": ["nomnomnomnom"],
+      "range": "1.3.2 - 1.12.0",
+      "nodes": ["node_modules/underscore"],
+      "fixAvailable": {
+        "name": "isparta",
+        "version": "3.0.4",
+        "isSemVerMajor": true
+      }
+    },
+    "vinyl-fs": {
+      "name": "vinyl-fs",
+      "severity": "high",
+      "isDirect": false,
+      "via": ["glob-stream"],
+      "effects": ["gulp"],
+      "range": ">=2.4.2",
+      "nodes": ["node_modules/vinyl-fs"],
+      "fixAvailable": {
+        "name": "gulp",
+        "version": "3.9.1",
+        "isSemVerMajor": true
+      }
+    },
+    "yargs": {
+      "name": "yargs",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": ["os-locale", "yargs-parser"],
+      "effects": [],
+      "range": "8.0.0-candidate.0 - 12.0.5",
+      "nodes": ["node_modules/nsp/node_modules/yargs"],
+      "fixAvailable": true
+    },
+    "yargs-parser": {
+      "name": "yargs-parser",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1005534,
+          "name": "yargs-parser",
+          "dependency": "yargs-parser",
+          "title": "Prototype Pollution in yargs-parser",
+          "url": "https://github.com/advisories/GHSA-p9pc-299p-vxgp",
+          "severity": "moderate",
+          "range": ">=6.0.0 <13.1.2"
+        }
+      ],
+      "effects": ["yargs"],
+      "range": "6.0.0 - 13.1.1",
+      "nodes": ["node_modules/nsp/node_modules/yargs-parser"],
+      "fixAvailable": true
+    }
+  },
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 2,
+      "moderate": 8,
+      "high": 15,
+      "critical": 1,
+      "total": 26
+    },
+    "dependencies": {
+      "prod": 32,
+      "dev": 1129,
+      "optional": 41,
+      "peer": 0,
+      "peerOptional": 0,
+      "total": 1160
+    }
+  }
+}

--- a/test/handlers/flags.test.ts
+++ b/test/handlers/flags.test.ts
@@ -15,7 +15,7 @@ describe('Flags', () => {
 
       const auditCommand = 'npm audit';
       const auditLevel = 'info';
-      const exceptionIds: number[] = [];
+      const exceptionIds: string[] = [];
       expect(callbackStub.calledWith(auditCommand, auditLevel, exceptionIds)).to.equal(true);
     });
   });
@@ -27,7 +27,7 @@ describe('Flags', () => {
       const options = { exclude: '1567,919' };
       const auditCommand = 'npm audit';
       const auditLevel = 'info';
-      const exceptionIds = [1567, 919];
+      const exceptionIds = ['1567', '919'];
 
       expect(callbackStub.called).to.equal(false);
       handleInput(options, callbackStub);
@@ -38,26 +38,14 @@ describe('Flags', () => {
       // with space
       options.exclude = '1567, 1902';
       handleInput(options, callbackStub);
-      expect(callbackStub.calledWith(auditCommand, auditLevel, [1567, 1902])).to.equal(true);
+      expect(callbackStub.calledWith(auditCommand, auditLevel, ['1567', '1902'])).to.equal(true);
       expect(consoleStub.calledWith('Exception IDs: 1567, 1902')).to.equal(true);
 
-      // invalid exceptions
-      options.exclude = '1134,undefined,888';
+      // string ID
+      options.exclude = '1134,GWE-1234,888';
       handleInput(options, callbackStub);
-      expect(callbackStub.calledWith(auditCommand, auditLevel, [1134, 888])).to.equal(true);
-      expect(consoleStub.calledWith('Exception IDs: 1134, 888')).to.equal(true);
-
-      // invalid NaN
-      options.exclude = '1134,NaN,3e,828';
-      handleInput(options, callbackStub);
-      expect(callbackStub.calledWith(auditCommand, auditLevel, [1134, 828])).to.equal(true);
-      expect(consoleStub.calledWith('Exception IDs: 1134, 828')).to.equal(true);
-
-      // invalid decimals
-      options.exclude = '1199,29.41,628';
-      handleInput(options, callbackStub);
-      expect(callbackStub.calledWith(auditCommand, auditLevel, [1199, 628])).to.equal(true);
-      expect(consoleStub.calledWith('Exception IDs: 1199, 628')).to.equal(true);
+      expect(callbackStub.calledWith(auditCommand, auditLevel, ['1134', 'GWE-1234', '888'])).to.equal(true);
+      expect(consoleStub.calledWith('Exception IDs: 1134, GWE-1234, 888')).to.equal(true);
 
       consoleStub.restore();
     });
@@ -68,7 +56,7 @@ describe('Flags', () => {
       const options = { exclude: '1567,919' };
       const auditCommand = 'npm audit';
       const auditLevel = 'info';
-      const exceptionIds = [1567, 919];
+      const exceptionIds = ['1567', '919'];
 
       expect(callbackStub.called).to.equal(false);
       handleInput(options, callbackStub);
@@ -87,7 +75,7 @@ describe('Flags', () => {
       const options = {};
       const auditCommand = 'npm audit';
       const auditLevel = 'info';
-      const exceptionIds: number[] = [];
+      const exceptionIds: string[] = [];
 
       expect(callbackStub.called).to.equal(false);
       handleInput(options, callbackStub);
@@ -106,7 +94,7 @@ describe('Flags', () => {
       const options = { production: true };
       const auditCommand = 'npm audit --production';
       const auditLevel = 'info';
-      const exceptionIds: number[] = [];
+      const exceptionIds: string[] = [];
 
       expect(callbackStub.called).to.equal(false);
       handleInput(options, callbackStub);
@@ -121,7 +109,7 @@ describe('Flags', () => {
       const options: CommandOptions = { registry: 'https://registry.npmjs.org/' };
       const auditCommand = 'npm audit --registry=https://registry.npmjs.org/';
       const auditLevel = 'info';
-      const exceptionIds: number[] = [];
+      const exceptionIds: string[] = [];
 
       expect(callbackStub.called).to.equal(false);
       handleInput(options, callbackStub);
@@ -136,7 +124,7 @@ describe('Flags', () => {
       let options: CommandOptions = { level: 'info' };
 
       const auditCommand = 'npm audit';
-      const exceptionIds: number[] = [];
+      const exceptionIds: string[] = [];
 
       expect(callbackStub.called).to.equal(false);
       handleInput(options, callbackStub);
@@ -201,7 +189,7 @@ describe('Flags', () => {
       const options = { moduleIgnore: 'lodash,moment' };
       const auditCommand = 'npm audit';
       const auditLevel = 'info';
-      const exceptionIds: number[] = [];
+      const exceptionIds: string[] = [];
       const modulesToIgnore = ['lodash', 'moment'];
 
       expect(callbackStub.called).to.equal(false);

--- a/test/handlers/handleFinish.test.ts
+++ b/test/handlers/handleFinish.test.ts
@@ -12,7 +12,7 @@ describe('Events handling', () => {
     const consoleStub = sinon.stub(console, 'error');
     const jsonBuffer = '';
     const auditLevel = 'info';
-    const exceptionIds: number[] = [];
+    const exceptionIds: string[] = [];
     const modulesToIgnore: string[] = [];
 
     expect(processStub.called).to.equal(false);
@@ -35,7 +35,7 @@ describe('Events handling', () => {
     const consoleStub = sinon.stub(console, 'info');
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER_EMPTY);
     const auditLevel = 'info';
-    const exceptionIds: number[] = [];
+    const exceptionIds: string[] = [];
     const modulesToIgnore: string[] = [];
 
     expect(consoleStub.called).to.equal(false);
@@ -56,7 +56,7 @@ describe('Events handling', () => {
     const consoleStub = sinon.stub(console, 'info');
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER);
     const auditLevel = 'info';
-    const exceptionIds = [975, 985, 1179, 1213, 1500, 1523, 1555, 1556, 1589];
+    const exceptionIds = ['975', '985', '1179', '1213', '1500', '1523', '1555', '1556', '1589'];
     const modulesToIgnore = ['swagger-ui', 'mem'];
 
     expect(consoleStub.called).to.equal(false);
@@ -78,7 +78,7 @@ describe('Events handling', () => {
     const consoleInfoStub = sinon.stub(console, 'info');
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER);
     const auditLevel = 'info';
-    const exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555];
+    const exceptionIds = ['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555'];
     const modulesToIgnore: string[] = [];
 
     expect(processStub.called).to.equal(false);
@@ -108,7 +108,7 @@ describe('Events handling', () => {
     const auditLevel = 'info';
     let modulesToIgnore = ['fakeModule1', 'fakeModule2'];
 
-    let exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 2001];
+    let exceptionIds = ['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555', '2001'];
 
     expect(processStub.called).to.equal(false);
     expect(consoleErrorStub.called).to.equal(false);
@@ -131,7 +131,7 @@ describe('Events handling', () => {
     expect(consoleWarnStub.calledWith(message)).to.equal(true);
 
     // Message for multiple unused exceptions
-    exceptionIds = [975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 2001, 2002];
+    exceptionIds = ['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555', '2001', '2002'];
     modulesToIgnore = ['fakeModule1'];
     handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
     // eslint-disable-next-line max-len

--- a/test/handlers/handleFinish.test.ts
+++ b/test/handlers/handleFinish.test.ts
@@ -13,12 +13,12 @@ describe('Events handling', () => {
     const jsonBuffer = '';
     const auditLevel = 'info';
     const exceptionIds: string[] = [];
-    const modulesToIgnore: string[] = [];
+    const exceptionModules: string[] = [];
 
     expect(processStub.called).to.equal(false);
     expect(consoleStub.called).to.equal(false);
 
-    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, exceptionModules);
 
     expect(processStub.called).to.equal(true);
     expect(processStub.calledWith(1)).to.equal(true);
@@ -36,10 +36,10 @@ describe('Events handling', () => {
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER_EMPTY);
     const auditLevel = 'info';
     const exceptionIds: string[] = [];
-    const modulesToIgnore: string[] = [];
+    const exceptionModules: string[] = [];
 
     expect(consoleStub.called).to.equal(false);
-    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, exceptionModules);
 
     expect(processStub.called).to.equal(true);
     expect(processStub.calledWith(0)).to.equal(true);
@@ -57,10 +57,10 @@ describe('Events handling', () => {
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER);
     const auditLevel = 'info';
     const exceptionIds = ['975', '985', '1179', '1213', '1500', '1523', '1555', '1556', '1589'];
-    const modulesToIgnore = ['swagger-ui', 'mem'];
+    const exceptionModules = ['swagger-ui', 'mem'];
 
     expect(consoleStub.called).to.equal(false);
-    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, exceptionModules);
 
     expect(processStub.called).to.equal(true);
     expect(processStub.calledWith(0)).to.equal(true);
@@ -79,13 +79,13 @@ describe('Events handling', () => {
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER);
     const auditLevel = 'info';
     const exceptionIds = ['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555'];
-    const modulesToIgnore: string[] = [];
+    const exceptionModules: string[] = [];
 
     expect(processStub.called).to.equal(false);
     expect(consoleErrorStub.called).to.equal(false);
     expect(consoleInfoStub.called).to.equal(false);
 
-    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, exceptionModules);
 
     expect(processStub.called).to.equal(true);
     expect(consoleErrorStub.called).to.equal(true);
@@ -106,8 +106,7 @@ describe('Events handling', () => {
     const consoleInfoStub = sinon.stub(console, 'info');
     const jsonBuffer = JSON.stringify(V6_JSON_BUFFER);
     const auditLevel = 'info';
-    let modulesToIgnore = ['fakeModule1', 'fakeModule2'];
-
+    let exceptionModules = ['fakeModule1', 'fakeModule2'];
     let exceptionIds = ['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555', '2001'];
 
     expect(processStub.called).to.equal(false);
@@ -115,7 +114,7 @@ describe('Events handling', () => {
     expect(consoleWarnStub.called).to.equal(false);
     expect(consoleInfoStub.called).to.equal(false);
 
-    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, exceptionModules);
 
     expect(processStub.called).to.equal(true);
     expect(processStub.calledWith(1)).to.equal(true);
@@ -126,16 +125,24 @@ describe('Events handling', () => {
     expect(consoleWarnStub.called).to.equal(true);
 
     // Message for one unused exception
-    // eslint-disable-next-line max-len
-    let message = `1 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001. It can be removed from the .nsprc file or --exclude -x flags. 2 of the ignored modules did not match any of the found vulnerabilites: fakeModule1, fakeModule2. They can be removed from the --module-ignore -m flags.`;
+    let message = [
+      '1 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001.',
+      'It can be removed from the .nsprc file or --exclude -x flags.',
+      '2 of the ignored modules did not match any of the found vulnerabilities: fakeModule1, fakeModule2.',
+      'They can be removed from the --module-ignore -m flags.',
+    ].join(' ');
     expect(consoleWarnStub.calledWith(message)).to.equal(true);
 
     // Message for multiple unused exceptions
     exceptionIds = ['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555', '2001', '2002'];
-    modulesToIgnore = ['fakeModule1'];
-    handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore);
-    // eslint-disable-next-line max-len
-    message = `2 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001, 2002. They can be removed from the .nsprc file or --exclude -x flags. 1 of the ignored modules did not match any of the found vulnerabilites: fakeModule1. It can be removed from the --module-ignore -m flags.`;
+    exceptionModules = ['fakeModule1'];
+    handleFinish(jsonBuffer, auditLevel, exceptionIds, exceptionModules);
+    message = [
+      '2 of the excluded vulnerabilities did not match any of the found vulnerabilities: 2001, 2002.',
+      'They can be removed from the .nsprc file or --exclude -x flags.',
+      '1 of the ignored modules did not match any of the found vulnerabilities: fakeModule1.',
+      'It can be removed from the --module-ignore -m flags.',
+    ].join(' ');
     expect(consoleWarnStub.calledWith(message)).to.equal(true);
 
     processStub.restore();

--- a/test/utils/vulnerability.test.ts
+++ b/test/utils/vulnerability.test.ts
@@ -1,6 +1,13 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { mapLevelToNumber, processAuditJson, processExceptions, getExceptionsIds } from '../../src/utils/vulnerability';
+import {
+  mapLevelToNumber,
+  processAuditJson,
+  processExceptions,
+  getExceptionsIds,
+  validateV6Vulnerability,
+  validateV7Vulnerability,
+} from '../../src/utils/vulnerability';
 
 import NSPRC from '../__mocks__/nsprc.json';
 import EXCEPTION_TABLE_DATA from '../__mocks__/exception-table-data.json';
@@ -10,8 +17,101 @@ import V6_JSON_BUFFER_EMPTY from '../__mocks__/v6-json-buffer-empty.json';
 import V7_SECURITY_REPORT_TABLE_DATA from '../__mocks__/v7-security-report-table-data.json';
 import V7_JSON_BUFFER from '../__mocks__/v7-json-buffer.json';
 import V7_JSON_BUFFER_EMPTY from '../__mocks__/v7-json-buffer-empty.json';
+import { v6Advisory, v7VulnerabilityVia } from '../../src/types';
 
 describe('Vulnerability utils', () => {
+  describe('validateV6Vulnerability', () => {
+    it('should be able to validate an exception by ID', () => {
+      const v6Advisory: v6Advisory = {
+        id: 1556,
+        cves: [],
+        cwe: '',
+        url: '',
+        module_name: '',
+        title: '',
+        findings: [],
+        severity: 'low',
+      };
+      expect(validateV6Vulnerability(v6Advisory, ['1556'])).to.equal(true);
+      expect(validateV6Vulnerability(v6Advisory, ['1557'])).to.equal(false);
+    });
+
+    it('should be able to validate an exception by cves list', () => {
+      const v6Advisory: v6Advisory = {
+        id: 0,
+        cves: ['CVE-2020-15168'],
+        cwe: '',
+        url: '',
+        module_name: '',
+        title: '',
+        findings: [],
+        severity: 'low',
+      };
+      expect(validateV6Vulnerability(v6Advisory, ['CVE-2020-15168'])).to.equal(true);
+      expect(validateV6Vulnerability(v6Advisory, ['CVE-2020-15167'])).to.equal(false);
+    });
+
+    it('should be able to validate an exception by cwe', () => {
+      const v6Advisory: v6Advisory = {
+        id: 0,
+        cves: [],
+        cwe: 'CWE-400',
+        url: '',
+        module_name: '',
+        title: '',
+        findings: [],
+        severity: 'low',
+      };
+      expect(validateV6Vulnerability(v6Advisory, ['CWE-400'])).to.equal(true);
+      expect(validateV6Vulnerability(v6Advisory, ['CWE-401'])).to.equal(false);
+    });
+
+    it('should be able to validate an exception by partial url', () => {
+      const v6Advisory: v6Advisory = {
+        id: 0,
+        cves: [''],
+        cwe: '',
+        url: 'https://npmjs.com/advisories/1556',
+        module_name: '',
+        title: '',
+        findings: [],
+        severity: 'low',
+      };
+      expect(validateV6Vulnerability(v6Advisory, ['1556'])).to.equal(true);
+      expect(validateV6Vulnerability(v6Advisory, ['1557'])).to.equal(false);
+    });
+  });
+
+  describe('validateV7Vulnerability', () => {
+    it('should be able to validate an exception by ID', () => {
+      const v7VulnerabilityVia: v7VulnerabilityVia = {
+        source: 1556,
+        url: '',
+        name: '',
+        title: '',
+        severity: 'low',
+        range: '',
+        dependency: '',
+      };
+      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1556'])).to.equal(true);
+      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1557'])).to.equal(false);
+    });
+
+    it('should be able to validate an exception by partial url', () => {
+      const v7VulnerabilityVia: v7VulnerabilityVia = {
+        source: 0,
+        url: 'https://npmjs.com/advisories/1556',
+        name: '',
+        title: '',
+        severity: 'low',
+        range: '',
+        dependency: '',
+      };
+      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1556'])).to.equal(true);
+      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1557'])).to.equal(false);
+    });
+  });
+
   describe('#mapLevelToNumber', () => {
     it('should be able to map audit level to correct numbers', () => {
       expect(mapLevelToNumber('info')).to.equal(0);
@@ -25,10 +125,10 @@ describe('Vulnerability utils', () => {
   describe('#getExceptionsIds', () => {
     it('should display the vulnerabilities from command line if .nsprc file not given', () => {
       const consoleStub = sinon.stub(console, 'info');
-      const cmdExceptions = [1165, 1890];
+      const cmdExceptions = ['1165', '1890'];
       expect(consoleStub.called).to.equal(false);
       const result = getExceptionsIds(false, cmdExceptions);
-      expect(result).to.have.length(2).and.deep.equal([1165, 1890]);
+      expect(result).to.have.length(2).and.deep.equal(['1165', '1890']);
       expect(consoleStub.called).to.equal(true);
       expect(consoleStub.calledWith('Exception IDs: 1165, 1890')).to.equal(true);
       consoleStub.restore();
@@ -36,10 +136,12 @@ describe('Vulnerability utils', () => {
 
     it('should combine the exceptions from command line and .nsprc file', () => {
       const consoleStub = sinon.stub(console, 'info');
-      const cmdExceptions = [1165, 1890];
+      const cmdExceptions = ['1165', '1890'];
       expect(consoleStub.called).to.equal(false);
       const result = getExceptionsIds(NSPRC, cmdExceptions);
-      expect(result).to.have.length(7).and.deep.equal([1165, 1890, 985, 1213, 2000, 2001, 2100]);
+      expect(result)
+        .to.have.length(9)
+        .and.deep.equal(['1165', '1890', '985', '1213', '2000', '2001', '2100', 'CWE-126', 'GHSA-ww39-953v-wcq6']);
       expect(consoleStub.called).to.equal(true); // Print security report
       consoleStub.restore();
     });
@@ -47,60 +149,51 @@ describe('Vulnerability utils', () => {
 
   describe('#processExceptions', () => {
     it('should be able to process exceptions correctly', () => {
-      const cmdExceptions = [1165, 1890];
+      const cmdExceptions = ['1165', '1890'];
       const result = processExceptions(NSPRC, cmdExceptions);
 
       expect(result).to.have.property('exceptionIds');
-      expect(result.exceptionIds).to.have.length(7).and.to.deep.equal([1165, 1890, 985, 1213, 2000, 2001, 2100]);
+      expect(result.exceptionIds)
+        .to.have.length(9)
+        .and.to.deep.equal(['1165', '1890', '985', '1213', '2000', '2001', '2100', 'CWE-126', 'GHSA-ww39-953v-wcq6']);
       expect(result).to.have.property('report');
-      expect(result.report).to.have.length(15).and.to.deep.equal(EXCEPTION_TABLE_DATA);
+      expect(result.report).to.have.length(16).and.to.deep.equal(EXCEPTION_TABLE_DATA);
     });
 
     it('should be able to filter active exceptions and label correctly', () => {
       const result = processExceptions(NSPRC);
-      expect(result).to.have.property('exceptionIds').and.to.have.length(5);
+      expect(result).to.have.property('exceptionIds').and.to.have.length(7);
       expect(result).to.have.property('report');
 
       const activeExceptionIds = result.report
         .filter((exception: string[]) => exception[1] === '\u001b[32mactive\u001b[0m')
-        .map((each: (string | number)[]) => Number(each[0]));
-      expect(activeExceptionIds).to.have.length(5).to.deep.equal([985, 1213, 2000, 2001, 2100]);
+        .map((each: (string | number)[]) => each[0]);
+      expect(activeExceptionIds).to.have.length(7).to.deep.equal(['985', '1213', '2000', '2001', '2100', 'CWE-126', 'GHSA-ww39-953v-wcq6']);
     });
 
     it('should be able to filter inactive exceptions and label correctly', () => {
       const result = processExceptions(NSPRC);
-      expect(result).to.have.property('exceptionIds').and.to.have.length(5);
+      expect(result).to.have.property('exceptionIds').and.to.have.length(7);
       expect(result).to.have.property('report');
 
       const activeExceptionIds = result.report
         .filter((exception: string[]) => exception[1] === '\u001b[33minactive\u001b[0m')
-        .map((each: (string | number)[]) => Number(each[0]));
-      expect(activeExceptionIds).to.have.length(1).to.deep.equal([976]);
+        .map((each: (string | number)[]) => each[0]);
+      expect(activeExceptionIds).to.have.length(1).to.deep.equal(['976']);
     });
 
     it('should be able to filter expired exceptions and label correctly', () => {
       const dateStub = sinon.stub(Date, 'now').returns(new Date(Date.UTC(2021, 6, 1)).valueOf());
       const result = processExceptions(NSPRC);
-      expect(result).to.have.property('exceptionIds').and.to.have.length(5);
-      expect(result).to.have.property('report').and.to.have.length(13);
+      expect(result).to.have.property('exceptionIds').and.to.have.length(7);
+      expect(result).to.have.property('report').and.to.have.length(14);
       const activeExceptionIds = result.report
         .filter((exception: string[]) => exception[1] === '\u001b[31mexpired\u001b[0m')
-        .map((each: (string | number)[]) => Number(each[0]));
-      expect(activeExceptionIds).to.have.length(6).to.deep.equal([975, 1084, 1179, 1556, 1651, 1654]);
+        .map((each: (string | number)[]) => each[0]);
+      expect(activeExceptionIds).to.have.length(6).to.deep.equal(['975', '1084', '1179', '1556', '1651', '1654']);
 
       // Clean up
       dateStub.restore();
-    });
-
-    it('should be able to filter invalid exceptions and label correctly', () => {
-      const result = processExceptions(NSPRC);
-      expect(result).to.have.property('exceptionIds').and.to.have.length(5);
-      expect(result).to.have.property('report');
-
-      const activeExceptionIds = result.report
-        .filter((exception: string[]) => exception[1] === '\u001b[31minvalid\u001b[0m')
-        .map((each: (string | number)[]) => each[0]);
-      expect(activeExceptionIds).to.have.length(1).to.deep.equal(['Note']);
     });
   });
 
@@ -128,12 +221,12 @@ describe('Vulnerability utils', () => {
         expect(processAuditJson(jsonString, auditLevel))
           .to.have.property('unhandledIds')
           .and.to.have.length(11)
-          .and.to.deep.equal([975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 1556, 1589]);
+          .and.to.deep.equal(['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555', '1556', '1589']);
 
-        expect(processAuditJson(jsonString, auditLevel, [975, 1179, 1589], ['dot-prop']))
+        expect(processAuditJson(jsonString, auditLevel, ['975', '1179', '1589'], ['dot-prop']))
           .to.have.property('unhandledIds')
           .and.to.have.length(7)
-          .and.to.deep.equal([976, 985, 1084, 1500, 1523, 1555, 1556]);
+          .and.to.deep.equal(['976', '985', '1084', '1500', '1523', '1555', '1556']);
       });
 
       it('should be able to list all the reported vulnerabilities', () => {
@@ -144,7 +237,7 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('vulnerabilityIds');
         expect(result.vulnerabilityIds)
           .to.have.length(11)
-          .and.to.deep.equal([975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 1556, 1589]);
+          .and.to.deep.equal(['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555', '1556', '1589']);
         expect(result).to.have.property('vulnerabilityModules');
         expect(result.vulnerabilityModules)
           .to.have.length(9)
@@ -170,7 +263,9 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
-        expect(result.unhandledIds).to.have.length(11).and.to.deep.equal([975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 1556, 1589]);
+        expect(result.unhandledIds)
+          .to.have.length(11)
+          .and.to.deep.equal(['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555', '1556', '1589']);
       });
 
       it('should be able to get low level vulnerabilities from JSON buffer', () => {
@@ -183,7 +278,9 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
-        expect(result.unhandledIds).to.have.length(11).and.to.deep.equal([975, 976, 985, 1084, 1179, 1213, 1500, 1523, 1555, 1556, 1589]);
+        expect(result.unhandledIds)
+          .to.have.length(11)
+          .and.to.deep.equal(['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555', '1556', '1589']);
       });
 
       it('should be able to get moderate level vulnerabilities from JSON buffer', () => {
@@ -196,7 +293,7 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
-        expect(result.unhandledIds).to.have.length(5).and.to.deep.equal([975, 976, 985, 1213, 1555]);
+        expect(result.unhandledIds).to.have.length(5).and.to.deep.equal(['975', '976', '985', '1213', '1555']);
       });
 
       it('should be able to get high level vulnerabilities from JSON buffer', () => {
@@ -209,7 +306,7 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
-        expect(result.unhandledIds).to.have.length(2).and.to.deep.equal([1213, 1555]);
+        expect(result.unhandledIds).to.have.length(2).and.to.deep.equal(['1213', '1555']);
       });
 
       it('should be able to get critical level vulnerabilities from JSON buffer', () => {
@@ -222,7 +319,7 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
-        expect(result.unhandledIds).to.have.length(1).and.to.deep.equal([1555]);
+        expect(result.unhandledIds).to.have.length(1).and.to.deep.equal(['1555']);
       });
     });
 
@@ -251,7 +348,7 @@ describe('Vulnerability utils', () => {
           .and.to.have.length(11)
           .and.to.deep.equal([1555, 1213, 1589, 1523, 1084, 1179, 1556, 975, 976, 985, 1500]);
 
-        expect(processAuditJson(jsonString, auditLevel, [975, 1179, 1589], ['dot-prop', 'yargs-parser']))
+        expect(processAuditJson(jsonString, auditLevel, ['975', '1179', '1589'], ['dot-prop', 'yargs-parser']))
           .to.have.property('unhandledIds')
           .and.to.have.length(6)
           .and.to.deep.equal([1555, 1523, 1084, 1556, 976, 985]);
@@ -265,7 +362,7 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('vulnerabilityIds');
         expect(result.vulnerabilityIds)
           .to.have.length(11)
-          .and.to.deep.equal([1555, 1213, 1589, 1523, 1084, 1179, 1556, 975, 976, 985, 1500]);
+          .and.to.deep.equal(['1555', '1213', '1589', '1523', '1084', '1179', '1556', '975', '976', '985', '1500']);
         expect(result).to.have.property('vulnerabilityModules');
         expect(result.vulnerabilityModules)
           .to.have.length(9)

--- a/test/utils/vulnerability.test.ts
+++ b/test/utils/vulnerability.test.ts
@@ -7,6 +7,7 @@ import {
   getExceptionsIds,
   validateV6Vulnerability,
   validateV7Vulnerability,
+  handleUnusedExceptions,
 } from '../../src/utils/vulnerability';
 
 import NSPRC from '../__mocks__/nsprc.json';
@@ -32,8 +33,8 @@ describe('Vulnerability utils', () => {
         findings: [],
         severity: 'low',
       };
-      expect(validateV6Vulnerability(v6Advisory, ['1556'])).to.equal(true);
-      expect(validateV6Vulnerability(v6Advisory, ['1557'])).to.equal(false);
+      expect(validateV6Vulnerability(v6Advisory, ['1556'])).to.deep.equal({ isExcepted: true, usedExceptionKey: '1556' });
+      expect(validateV6Vulnerability(v6Advisory, ['1557'])).to.deep.equal({ isExcepted: false, usedExceptionKey: '' });
     });
 
     it('should be able to validate an exception by cves list', () => {
@@ -47,8 +48,11 @@ describe('Vulnerability utils', () => {
         findings: [],
         severity: 'low',
       };
-      expect(validateV6Vulnerability(v6Advisory, ['CVE-2020-15168'])).to.equal(true);
-      expect(validateV6Vulnerability(v6Advisory, ['CVE-2020-15167'])).to.equal(false);
+      expect(validateV6Vulnerability(v6Advisory, ['CVE-2020-15168'])).to.deep.equal({
+        isExcepted: true,
+        usedExceptionKey: 'CVE-2020-15168',
+      });
+      expect(validateV6Vulnerability(v6Advisory, ['CVE-2020-15167'])).to.deep.equal({ isExcepted: false, usedExceptionKey: '' });
     });
 
     it('should be able to validate an exception by cwe', () => {
@@ -62,8 +66,8 @@ describe('Vulnerability utils', () => {
         findings: [],
         severity: 'low',
       };
-      expect(validateV6Vulnerability(v6Advisory, ['CWE-400'])).to.equal(true);
-      expect(validateV6Vulnerability(v6Advisory, ['CWE-401'])).to.equal(false);
+      expect(validateV6Vulnerability(v6Advisory, ['CWE-400'])).to.deep.equal({ isExcepted: true, usedExceptionKey: 'CWE-400' });
+      expect(validateV6Vulnerability(v6Advisory, ['CWE-401'])).to.deep.equal({ isExcepted: false, usedExceptionKey: '' });
     });
 
     it('should be able to validate an exception by partial url', () => {
@@ -77,8 +81,8 @@ describe('Vulnerability utils', () => {
         findings: [],
         severity: 'low',
       };
-      expect(validateV6Vulnerability(v6Advisory, ['1556'])).to.equal(true);
-      expect(validateV6Vulnerability(v6Advisory, ['1557'])).to.equal(false);
+      expect(validateV6Vulnerability(v6Advisory, ['1556'])).to.deep.equal({ isExcepted: true, usedExceptionKey: '1556' });
+      expect(validateV6Vulnerability(v6Advisory, ['1557'])).to.deep.equal({ isExcepted: false, usedExceptionKey: '' });
     });
   });
 
@@ -93,8 +97,8 @@ describe('Vulnerability utils', () => {
         range: '',
         dependency: '',
       };
-      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1556'])).to.equal(true);
-      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1557'])).to.equal(false);
+      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1556'])).to.deep.equal({ isExcepted: true, usedExceptionKey: '1556' });
+      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1557'])).to.deep.equal({ isExcepted: false, usedExceptionKey: '' });
     });
 
     it('should be able to validate an exception by partial url', () => {
@@ -107,8 +111,8 @@ describe('Vulnerability utils', () => {
         range: '',
         dependency: '',
       };
-      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1556'])).to.equal(true);
-      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1557'])).to.equal(false);
+      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1556'])).to.deep.equal({ isExcepted: true, usedExceptionKey: '1556' });
+      expect(validateV7Vulnerability(v7VulnerabilityVia, ['1557'])).to.deep.equal({ isExcepted: false, usedExceptionKey: '' });
     });
   });
 
@@ -212,6 +216,10 @@ describe('Vulnerability utils', () => {
         expect(result.unhandledIds).to.have.length(0).and.to.deep.equal([]);
         expect(result).to.have.property('report');
         expect(result.report).to.have.length(0).and.to.deep.equal([]);
+        expect(result).to.have.property('unusedExceptionIds');
+        expect(result.unusedExceptionIds).to.have.length(0).and.to.deep.equal([]);
+        expect(result).to.have.property('unusedExceptionModules');
+        expect(result.unusedExceptionModules).to.have.length(0).and.to.deep.equal([]);
       });
 
       it('should be able to except some of the reported vulnerabilities', () => {
@@ -227,6 +235,26 @@ describe('Vulnerability utils', () => {
           .to.have.property('unhandledIds')
           .and.to.have.length(7)
           .and.to.deep.equal(['976', '985', '1084', '1500', '1523', '1555', '1556']);
+      });
+
+      it('should be able to return unused exceptions', () => {
+        const jsonString = JSON.stringify(V6_JSON_BUFFER);
+        const auditLevel = 'info';
+        // "123", "456", "789" not in used
+        const exceptionIds = ['1179', '1213', '1500', '1523', '1555', '1556', '1589', '123', '456', '789'];
+        const exceptionModules = ['dots-parser', 'ini']; // "ini" is one of the vulnerability module
+        const result = processAuditJson(jsonString, auditLevel, exceptionIds, exceptionModules);
+
+        expect(result).to.have.property('vulnerabilityIds');
+        expect(result.vulnerabilityIds)
+          .to.have.length(11)
+          .and.to.deep.equal(['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555', '1556', '1589']);
+        expect(result).to.have.property('unhandledIds');
+        expect(result.unhandledIds).to.have.length(4).and.to.deep.equal(['975', '976', '985', '1084']);
+        expect(result).to.have.property('unusedExceptionIds');
+        expect(result.unusedExceptionIds).to.have.length(3).and.to.deep.equal(['123', '456', '789']);
+        expect(result).to.have.property('unusedExceptionModules');
+        expect(result.unusedExceptionModules).to.have.length(1).and.to.deep.equal(['dots-parser']);
       });
 
       it('should be able to list all the reported vulnerabilities', () => {
@@ -346,12 +374,12 @@ describe('Vulnerability utils', () => {
         expect(processAuditJson(jsonString, auditLevel))
           .to.have.property('unhandledIds')
           .and.to.have.length(11)
-          .and.to.deep.equal([1555, 1213, 1589, 1523, 1084, 1179, 1556, 975, 976, 985, 1500]);
+          .and.to.deep.equal(['1555', '1213', '1589', '1523', '1084', '1179', '1556', '975', '976', '985', '1500']);
 
         expect(processAuditJson(jsonString, auditLevel, ['975', '1179', '1589'], ['dot-prop', 'yargs-parser']))
           .to.have.property('unhandledIds')
           .and.to.have.length(6)
-          .and.to.deep.equal([1555, 1523, 1084, 1556, 976, 985]);
+          .and.to.deep.equal(['1555', '1523', '1084', '1556', '976', '985']);
       });
 
       it('should be able to list all the reported vulnerabilities', () => {
@@ -389,7 +417,9 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
-        expect(result.unhandledIds).to.have.length(11).and.to.deep.equal([1555, 1213, 1589, 1523, 1084, 1179, 1556, 975, 976, 985, 1500]);
+        expect(result.unhandledIds)
+          .to.have.length(11)
+          .and.to.deep.equal(['1555', '1213', '1589', '1523', '1084', '1179', '1556', '975', '976', '985', '1500']);
       });
 
       it('should be able to get low level vulnerabilities from JSON buffer', () => {
@@ -402,7 +432,9 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
-        expect(result.unhandledIds).to.have.length(11).and.to.deep.equal([1555, 1213, 1589, 1523, 1084, 1179, 1556, 975, 976, 985, 1500]);
+        expect(result.unhandledIds)
+          .to.have.length(11)
+          .and.to.deep.equal(['1555', '1213', '1589', '1523', '1084', '1179', '1556', '975', '976', '985', '1500']);
       });
 
       it('should be able to get moderate level vulnerabilities from JSON buffer', () => {
@@ -415,7 +447,7 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
-        expect(result.unhandledIds).to.have.length(5).and.to.deep.equal([1555, 1213, 975, 976, 985]);
+        expect(result.unhandledIds).to.have.length(5).and.to.deep.equal(['1555', '1213', '975', '976', '985']);
       });
 
       it('should be able to get high level vulnerabilities from JSON buffer', () => {
@@ -428,7 +460,7 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
-        expect(result.unhandledIds).to.have.length(2).and.to.deep.equal([1555, 1213]);
+        expect(result.unhandledIds).to.have.length(2).and.to.deep.equal(['1555', '1213']);
       });
 
       it('should be able to get critical level vulnerabilities from JSON buffer', () => {
@@ -441,8 +473,56 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('report').and.to.have.length(11);
 
         expect(result).to.have.property('unhandledIds');
-        expect(result.unhandledIds).to.have.length(1).and.to.deep.equal([1555]);
+        expect(result.unhandledIds).to.have.length(1).and.to.deep.equal(['1555']);
       });
+    });
+  });
+
+  describe('#handleUnusedExceptions', () => {
+    it('should be able to console log single unused exception message correctly', () => {
+      const consoleStub = sinon.stub(console, 'warn');
+      const unusedExceptionIds = ['1567'];
+      const unusedExceptionModules = ['dots-parser'];
+
+      expect(consoleStub.called).to.equal(false);
+      handleUnusedExceptions(unusedExceptionIds, unusedExceptionModules);
+
+      expect(consoleStub.called).to.equal(true);
+      expect(
+        consoleStub.calledWith(
+          [
+            '1 of the excluded vulnerabilities did not match any of the found vulnerabilities: 1567.',
+            'It can be removed from the .nsprc file or --exclude -x flags.',
+            '1 of the ignored modules did not match any of the found vulnerabilities: dots-parser.',
+            'It can be removed from the --module-ignore -m flags.',
+          ].join(' '),
+        ),
+      ).to.equal(true);
+
+      consoleStub.restore();
+    });
+
+    it('should be able to analyze multiple unused exceptions correctly', () => {
+      const consoleStub = sinon.stub(console, 'warn');
+      const unusedExceptionIds = ['1567', 'GHSA-ff7x-qrg7-qggm', 'CWE-471'];
+      const unusedExceptionModules = ['dots-parser', 'lodash', 'ini'];
+
+      expect(consoleStub.called).to.equal(false);
+      handleUnusedExceptions(unusedExceptionIds, unusedExceptionModules);
+
+      expect(consoleStub.called).to.equal(true);
+      expect(
+        consoleStub.calledWith(
+          [
+            '3 of the excluded vulnerabilities did not match any of the found vulnerabilities: 1567, GHSA-ff7x-qrg7-qggm, CWE-471.',
+            'They can be removed from the .nsprc file or --exclude -x flags.',
+            '3 of the ignored modules did not match any of the found vulnerabilities: dots-parser, lodash, ini.',
+            'They can be removed from the --module-ignore -m flags.',
+          ].join(' '),
+        ),
+      ).to.equal(true);
+
+      consoleStub.restore();
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
         "target": "es5",
         "module": "commonjs",
         "lib": [
-            "ES6",
-            "ES2015"
+            "ES2018"
         ],
         "outDir": "lib",
         "strict": true,


### PR DESCRIPTION
This change adds support for non-numeric exceptions and checks in more places in the audit result, newly supported IDs including CVE ID, CWE ID, GHSA ID, and full or partial URL.

Fix issues:
- https://github.com/jeemok/better-npm-audit/issues/76
- https://github.com/jeemok/better-npm-audit/issues/60