### PR TITLE
Adding yaml support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -441,7 +441,8 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "array-union": {
       "version": "2.1.0",
@@ -1261,14 +1262,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
-    "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "requires": {
-        "argparse": "^2.0.1"
-      }
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2060,6 +2053,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.0.tgz",
+      "integrity": "sha512-OuAINfTsoJrY5H7CBWnKZhX6nZciXBydrMtTHr1dC4nP40X5jyTIVlogZHxSlVZM8zSgXRfgZGsaHF4+pV+JRw=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -441,8 +441,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-union": {
       "version": "2.1.0",
@@ -1263,10 +1262,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -1417,6 +1415,17 @@
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "commander": "^8.0.0",
     "dayjs": "^1.10.6",
+    "js-yaml": "^4.1.0",
     "lodash.get": "^4.4.2",
     "table": "^6.7.1"
   },

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   "dependencies": {
     "commander": "^8.0.0",
     "dayjs": "^1.10.6",
-    "js-yaml": "^4.1.0",
     "lodash.get": "^4.4.2",
-    "table": "^6.7.1"
+    "table": "^6.7.1",
+    "yaml": "^2.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.19",

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,6 +1,4 @@
-import { ExecException } from "child_process";
-
-const { load } = require("js-yaml");
+import YAML from 'yaml';
 
 // TODO: This might be unused
 /**
@@ -18,14 +16,15 @@ export function isWholeNumber(value: string | number | null | undefined): boolea
 }
 
 /**
- * @param {string} string     The YAML stringified object
- * @returns {Boolean}         Returns true if the input string is parse-able
+ * @param {String} string       The YAML stringified object
+ * @param {Boolean} logError    A boolean that determines if the function should log a caught error to console
+ * @return {Boolean}            Returns true if the input string is parse-able
  */
-export function isYamlString(string: string, logError: boolean = true): boolean {
+export function isYamlString(string: string, logError = true): boolean {
   try {
-    load(string);
-  } catch(e){
-    if (logError){      
+    YAML.parse(string);
+  } catch (e) {
+    if (logError) {
       console.log('Failed parsing .nsprc file: ' + e);
       throw e;
     }
@@ -34,31 +33,31 @@ export function isYamlString(string: string, logError: boolean = true): boolean 
 }
 
 /**
- * @param {String} string     The YAML/JSON stringified object
- * @returns {Array<Boolean>}  An array with two booleans where the first determines if the input string was valid and the second if the contents are yaml or not.
+ * @param {String} string       The YAML/JSON stringified object
+ * @return {Array<Boolean>}     The first boolean determines if the input string was valid, the second if it is yaml or not
  */
-export function getValidStatusAndType(string: string): Array<Boolean> {
-  let isYaml = false;  
-  try{
-    if (isYaml = isYamlString(string, false) || isJsonString(string, false)){
+export function getValidStatusAndType(string: string): Array<boolean> {
+  let isYaml = false;
+  try {
+    if ((isYaml = isYamlString(string, false) || isJsonString(string, false))) {
       return [true, isYaml];
-    }      
+    }
   } catch (e) {
-    console.log('Failed parsing .nsprc file: ' + e);     
-  }  
-  return [false,false];
+    console.log('Failed parsing .nsprc file: ' + e);
+  }
+  return [false, false];
 }
 
 /**
  * @param  {String} string      The JSON stringified object
- * @param  {Boolean} logError  A boolean that determines if an error should be logged to console
+ * @param {Boolean} logError    A boolean that determines if the function should log a caught error to console
  * @return {Boolean}            Returns true if the input string is parse-able
  */
-export function isJsonString(string: string, logError: boolean = true): boolean {
+export function isJsonString(string: string, logError = true): boolean {
   try {
     JSON.parse(string);
   } catch (e) {
-    if (logError){
+    if (logError) {
       console.log('Failed parsing .nsprc file: ' + e);
     }
     return false;

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -20,7 +20,7 @@ export function isWholeNumber(value: string | number | null | undefined): boolea
  * @param {Boolean} logError    A boolean that determines if the function should log a caught error to console
  * @return {Boolean}            Returns true if the input string is parse-able
  */
-export function isYamlString(string: string, logError = true): boolean {
+export function isYamlString(string: string, logError:boolean = true): boolean {
   try {
     YAML.parse(string);
   } catch (e) {
@@ -53,7 +53,7 @@ export function getValidStatusAndType(string: string): Array<boolean> {
  * @param {Boolean} logError    A boolean that determines if the function should log a caught error to console
  * @return {Boolean}            Returns true if the input string is parse-able
  */
-export function isJsonString(string: string, logError = true): boolean {
+export function isJsonString(string: string, logError:boolean = true): boolean {
   try {
     JSON.parse(string);
   } catch (e) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,3 +1,7 @@
+import { ExecException } from "child_process";
+
+const { load } = require("js-yaml");
+
 // TODO: This might be unused
 /**
  * @param  {String | Number | Null | Boolean} value     The input number
@@ -14,14 +18,49 @@ export function isWholeNumber(value: string | number | null | undefined): boolea
 }
 
 /**
- * @param  {String} string    The JSON stringified object
- * @return {Boolean}          Returns true if the input string is parse-able
+ * @param {string} string     The YAML stringified object
+ * @returns {Boolean}         Returns true if the input string is parse-able
  */
-export function isJsonString(string: string): boolean {
+export function isYamlString(string: string, logError: boolean = true): boolean {
+  try {
+    load(string);
+  } catch(e){
+    if (logError){      
+      console.log('Failed parsing .nsprc file: ' + e);
+      throw e;
+    }
+  }
+  return true;
+}
+
+/**
+ * @param {String} string     The YAML/JSON stringified object
+ * @returns {Array<Boolean>}  An array with two booleans where the first determines if the input string was valid and the second if the contents are yaml or not.
+ */
+export function getValidStatusAndType(string: string): Array<Boolean> {
+  let isYaml = false;  
+  try{
+    if (isYaml = isYamlString(string, false) || isJsonString(string, false)){
+      return [true, isYaml];
+    }      
+  } catch (e) {
+    console.log('Failed parsing .nsprc file: ' + e);     
+  }  
+  return [false,false];
+}
+
+/**
+ * @param  {String} string      The JSON stringified object
+ * @param  {Boolean} logError  A boolean that determines if an error should be logged to console
+ * @return {Boolean}            Returns true if the input string is parse-able
+ */
+export function isJsonString(string: string, logError: boolean = true): boolean {
   try {
     JSON.parse(string);
   } catch (e) {
-    console.log('Failed parsing .nsprc file: ' + e);
+    if (logError){
+      console.log('Failed parsing .nsprc file: ' + e);
+    }
     return false;
   }
   return true;

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { NsprcFile } from 'src/types';
-import { isJsonString } from './common';
+import { getValidStatusAndType } from './common';
+const { load } = require("js-yaml");
 
 /**
  * Read file from path
@@ -8,12 +9,20 @@ import { isJsonString } from './common';
  * @return {(Object | Boolean)}   Returns the parsed data if found, or else returns `false`
  */
 export function readFile(path: string): NsprcFile | boolean {
-  try {
-    const data = fs.readFileSync(path, 'utf8');
-    if (!isJsonString(data)) {
-      return false;
+  try {    
+    const data = fs.readFileSync(path, 'utf8');    
+    const validAndType = getValidStatusAndType(data);
+
+    if(validAndType[0]){
+      if(validAndType[1]){
+        return load(data);
+      } else {
+        return JSON.parse(data);
+      }
     }
-    return JSON.parse(data);
+
+    return false;
+    
   } catch (err) {
     return false;
   }

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { NsprcFile } from 'src/types';
 import { getValidStatusAndType } from './common';
-const { load } = require("js-yaml");
+import YAML from 'yaml';
 
 /**
  * Read file from path
@@ -9,20 +9,19 @@ const { load } = require("js-yaml");
  * @return {(Object | Boolean)}   Returns the parsed data if found, or else returns `false`
  */
 export function readFile(path: string): NsprcFile | boolean {
-  try {    
-    const data = fs.readFileSync(path, 'utf8');    
+  try {
+    const data = fs.readFileSync(path, 'utf8');
     const validAndType = getValidStatusAndType(data);
 
-    if(validAndType[0]){
-      if(validAndType[1]){
-        return load(data);
+    if (validAndType[0]) {
+      if (validAndType[1]) {
+        return YAML.parse(data);
       } else {
         return JSON.parse(data);
       }
     }
 
     return false;
-    
   } catch (err) {
     return false;
   }


### PR DESCRIPTION
I've added basic support for writing YAML in the nsprc configuration file. This was requested in issue #70.

The basic idea was to use the package [yaml](https://www.npmjs.com/package/yaml) to parse the .nsprc file. I've ran this code with the the equivalent nsprc files
`1070404: 
  active: true
  notes: my note
  expiry: '2022-05-30'` 
  
  and
  
  `{
  "1070404": {
    "active": true,
    "notes": "These are my notes",
    "expiry": '2022-05-30'
  }
}`

on a project I'm working on which produced the same output. 

Let me know if there are any changes needed for the PR to be accepted. Thanks!