### PR TITLE
Use "--omit=dev" internally on newer npm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -259,6 +259,12 @@
       "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==",
       "dev": true
     },
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "@types/sinon": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.2.tgz",
@@ -1342,7 +1348,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -1661,10 +1666,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -2049,8 +2053,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "commander": "^8.0.0",
     "dayjs": "^1.10.6",
     "lodash.get": "^4.4.2",
+    "semver": "^7.3.8",
     "table": "^6.7.1"
   },
   "devDependencies": {
@@ -39,6 +40,7 @@
     "@types/lodash.get": "^4.4.6",
     "@types/mocha": "^8.2.3",
     "@types/node": "^16.0.0",
+    "@types/semver": "^7.3.13",
     "@types/sinon": "^10.0.2",
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",

--- a/src/handlers/handleInput.ts
+++ b/src/handlers/handleInput.ts
@@ -1,7 +1,22 @@
 import get from 'lodash.get';
+import semver from 'semver';
 import { AuditLevel, CommandOptions } from 'src/types';
+import { getNpmVersion } from '../utils/npm';
 import { readFile } from '../utils/file';
 import { getExceptionsIds } from '../utils/vulnerability';
+
+/**
+ * Get the `npm audit` flag to audit only production dependencies.
+ * @return {String} The flag.
+ */
+function getProductionOnlyOption() {
+  const npmVersion = getNpmVersion();
+  if (semver.satisfies(npmVersion, '<=8.13.2')) {
+    return '--production';
+  } else {
+    return '--omit=dev';
+  }
+}
 
 /**
  * Handle user's input
@@ -13,7 +28,7 @@ export default function handleInput(options: CommandOptions, fn: (T1: string, T2
   const auditCommand: string = [
     'npm audit',
     // flags
-    get(options, 'production') ? '--production' : '',
+    get(options, 'production') ? getProductionOnlyOption() : '',
     get(options, 'registry') ? `--registry=${options.registry}` : '',
   ]
     .filter(Boolean)

--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -1,0 +1,11 @@
+import { exec } from 'child_process';
+import { Readable } from 'stream';
+
+/**
+ * Get the current npm version
+ * @return {String} The npm version
+ */
+export function getNpmVersion(): string {
+  const version = exec('npm --version');
+  return (version.stdout as Readable).toString();
+}

--- a/test/handlers/flags.test.ts
+++ b/test/handlers/flags.test.ts
@@ -92,7 +92,7 @@ describe('Flags', () => {
     it('should be able to set production mode from the command flag correctly', () => {
       const callbackStub = sinon.stub();
       const options = { production: true };
-      const auditCommand = 'npm audit --production';
+      const auditCommand = 'npm audit --omit=dev';
       const auditLevel = 'info';
       const exceptionIds: string[] = [];
 


### PR DESCRIPTION
Closes #81

Update the behaviour when the `--production` flag is used on the CLI of this project to, instead of just using `--production` when invoking `npm audit`, do:
1. get the version of npm being used,
2. check the version against a version range[^1][^2]
3. use '--production' for older npm version, or
4. use '--omit=dev' for newer npm version.

Note that this change is not a breaking change for this project.

While I updated the tests, the tests as they are now are not ood. The current test suite assumes you're running them with a newer version of npm. It would be better if the tests are somehow run with a controlled version of npm instead, or better yet, with various versions of npm.


[^1]: The version range is probably incorrect as is. I based it on the GitHub issue with the idea to either let it evolve over time as reports come in, or adjust it after this commit if it's preferred that the range is (likely) correct before this is released.
[^2]: To perform the version range check I added a new runtime dependency, namely "semver". See: https://www.npmjs.com/package/semver