### PR TITLE
Fix getting npm version through CLI

### DIFF
--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -1,11 +1,10 @@
-import { exec } from 'child_process';
-import { Readable } from 'stream';
+import { execSync } from 'child_process';
 
 /**
  * Get the current npm version
  * @return {String} The npm version
  */
 export function getNpmVersion(): string {
-  const version = exec('npm --version');
-  return (version.stdout as Readable).toString();
+  const version = execSync('npm --version');
+  return version.toString();
 }

--- a/test/handlers/flags.test.ts
+++ b/test/handlers/flags.test.ts
@@ -1,7 +1,9 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
+import * as semver from 'semver';
 import { CommandOptions } from '../../src/types';
 import handleInput from '../../src/handlers/handleInput';
+import { getNpmVersion } from '../../src/utils/npm';
 
 describe('Flags', () => {
   describe('default', () => {
@@ -92,7 +94,9 @@ describe('Flags', () => {
     it('should be able to set production mode from the command flag correctly', () => {
       const callbackStub = sinon.stub();
       const options = { production: true };
-      const auditCommand = 'npm audit --omit=dev';
+      const npmVersion = getNpmVersion();
+      const flag = semver.satisfies(npmVersion, '<=8.13.2') ? '--production' : '--omit=dev';
+      const auditCommand = `npm audit ${flag}`;
       const auditLevel = 'info';
       const exceptionIds: string[] = [];
 


### PR DESCRIPTION
Followup to #86
Closes #98

Update the logic to get the npm version from the npm CLI to use the synchronous version of `exec`, `execSync`, to ensure the output can be read correctly. In the previous implementation the output would not be read correctly, leading to the comparison at `handleInput.ts:14` always evaluating to false and `'--omit=dev'` always being used.