### PR TITLE
Bump micromatch from 4.0.4 to 4.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1659,12 +1659,14 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"


### PR DESCRIPTION
This addresses CVE-2024-4067 / GHSA-952p-6rrq-rcjv as identified by `npm audit`.

Relates to

- https://github.com/jeemok/better-npm-audit/pull/99#issuecomment-2323354893
- https://github.com/jeemok/better-npm-audit/pull/100#issuecomment-2323359564