### PR TITLE
Respect the `NO_COLOR` environment variable

### DIFF
--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -49,6 +49,10 @@ const COLORS = <const>{
  * @return {String}             Message
  */
 export function color(message: string, fgColor?: Color, bgColor?: Color): string {
+  if ('NO_COLOR' in process.env) {
+    return message;
+  }
+
   return [
     <ColorCode>get(COLORS, `${fgColor}.fg`, ''),
     <ColorCode>get(COLORS, `${bgColor}.bg`, ''),


### PR DESCRIPTION
This addresses #85, potentially closing it.

I updated the implementation of the coloring logic in this project to respect the [`NO_COLOR`](https://no-color.org/) environment variable name to allow users to use the tool without colored output. An alternative approach could be to use an existing library for coloring, which might just support these kinds of features.

I briefly looked at adding a `--no-color` option[^1] and while this seems trivial the use of `console.error` ([example](https://github.com/jeemok/better-npm-audit/blob/b2f400fb14dea0421a52596b11864dc4d0fd1d92/src/handlers/handleFinish.ts#L46)) makes this non-trivial because every invocation would need to check `--no-color` (whereas it does respect `NO_COLOR`). Since I don't think it makes sense to perform this check every time `console.error` (or similar) is used, I think a larger refactoring of outputting is instead required if we want to support a flag like `--no-color`.

[^1]: A basic implementation can be achieved by adding `.option('--no-color', 'Disable colored output.')` to `index.ts` and `|| process.argv.includes('--no-color')` to `color.ts`.