### PR TITLE
Resolve #64: Add --filter-table flag to filter vulnerability display

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ Now you can run locally or in your CI pipeline:
 npm run audit
 ```
 
+### Filter vulnerability table
+
+You can filter the vulnerability table to show only vulnerabilities at or above a specified severity level using the `--filter-table` flag. This is useful for reducing noise in the output while maintaining the original audit behavior for exit codes.
+
+```bash
+# Filter table to show only high and critical vulnerabilities
+better-npm-audit audit --filter-table high
+
+# Filter table to match the audit level
+better-npm-audit audit --level moderate --filter-table
+
+# Set different levels for exit behavior vs table display
+better-npm-audit audit --level high --filter-table moderate
+```
+
+**Note:** The `--filter-table` flag only affects what vulnerabilities are displayed in the table. The audit level (`--level`) still controls the exit behavior and vulnerability counting.
+
 <br />
 
 ## Options
@@ -91,6 +108,7 @@ npm run audit
 | `--exclude`         | `-x`  | Exceptions or the vulnerabilities ID(s) to exclude; the ID can be the numeric ID, CVE, CWE or GHSA ID |
 | `--module-ignore`   | `-m`  | Names of modules to exclude                                                                           |
 | `--level`           | `-l`  | The minimum audit level to validate; Same as the original `--audit-level` flag                        |
+| `--filter-table`    | `-f`  | Filter the vulnerability table to show only vulnerabilities at or above the specified level. Accepts a level (`info`, `low`, `moderate`, `high`, `critical`) or can be used as a boolean flag to filter by the audit level |
 | `--production`      | `-p`  | Skip the `devDependencies`                                                                            |
 | `--registry`        | `-r`  | The npm registry url to use                                                                           |
 | `--include-columns` | `-i`  | Columns to include in report                                                                          |

--- a/index.ts
+++ b/index.ts
@@ -20,6 +20,7 @@ const program = new Command();
  * @param  {Array}  exceptionIds    List of vulnerability IDs to exclude
  * @param  {Array} modulesToIgnore  List of vulnerable modules to ignore in audit results
  * @param  {Array} columnsToInclude List of columns to include in audit results
+ * @param  {String} filterLevel     Optional level to filter table display
  */
 export function callback(
   auditCommand: string,
@@ -27,6 +28,7 @@ export function callback(
   exceptionIds: string[],
   modulesToIgnore: string[],
   columnsToInclude: string[],
+  filterLevel?: AuditLevel,
 ): void {
   // Increase the default max buffer size (1 MB)
   const audit = exec(`${auditCommand} --json`, { maxBuffer: MAX_BUFFER_SIZE });
@@ -40,7 +42,7 @@ export function callback(
 
   // Once the stdout has completed, process the output
   if (audit.stderr) {
-    audit.stderr.on('close', () => handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore, columnsToInclude));
+    audit.stderr.on('close', () => handleFinish(jsonBuffer, auditLevel, exceptionIds, modulesToIgnore, columnsToInclude, filterLevel));
     // stderr
     audit.stderr.on('data', console.error);
   }
@@ -54,6 +56,7 @@ program
   .option('-x, --exclude <ids>', 'Exceptions or the vulnerabilities ID(s) to exclude.')
   .option('-m, --module-ignore <moduleNames>', 'Names of modules to ignore.')
   .option('-l, --level <auditLevel>', 'The minimum audit level to validate.')
+  .option('-f, --filter-table [level]', 'Filter table to show only vulnerabilities at or above specified level (defaults to audit level if no value provided).')
   .option('-p, --production', 'Skip checking the devDependencies.')
   .option('-r, --registry <url>', 'The npm registry url to use.')
   .option('-i, --include-columns <columnName1>,<columnName2>,..,<columnNameN>', 'Columns to include in report.')

--- a/src/handlers/handleFinish.ts
+++ b/src/handlers/handleFinish.ts
@@ -9,6 +9,7 @@ import { processAuditJson, handleUnusedExceptions } from '../utils/vulnerability
  * @param  {Array} exceptionIds       List of vulnerability IDs to exclude
  * @param  {Array} exceptionModules   List of vulnerable modules to ignore in audit results
  * @param  {Array} columnsToInclude   List of columns to include in audit results
+ * @param  {String} filterLevel       Optional level to filter table display
  */
 export default function handleFinish(
   jsonBuffer: string,
@@ -16,6 +17,7 @@ export default function handleFinish(
   exceptionIds: string[],
   exceptionModules: string[],
   columnsToInclude: string[],
+  filterLevel?: AuditLevel,
 ): void {
   const { unhandledIds, report, failed, unusedExceptionIds, unusedExceptionModules } = processAuditJson(
     jsonBuffer,
@@ -23,6 +25,7 @@ export default function handleFinish(
     exceptionIds,
     exceptionModules,
     columnsToInclude,
+    filterLevel,
   );
 
   // If unable to process the audit JSON

--- a/src/handlers/handleInput.ts
+++ b/src/handlers/handleInput.ts
@@ -24,7 +24,7 @@ function getProductionOnlyOption() {
  */
 export default function handleInput(
   options: CommandOptions,
-  fn: (T1: string, T2: AuditLevel, T3: string[], T4: string[], T5: string[]) => void,
+  fn: (T1: string, T2: AuditLevel, T3: string[], T4: string[], T5: string[], T6?: AuditLevel) => void,
 ): void {
   // Generate NPM Audit command
   const auditCommand: string = [
@@ -40,6 +40,19 @@ export default function handleInput(
   const envVar = process.env.NPM_CONFIG_AUDIT_LEVEL as AuditLevel;
   const auditLevel: AuditLevel = get(options, 'level', envVar) || 'info';
 
+  // Process filter table option
+  let filterLevel: AuditLevel | undefined;
+  const filterTableOption = get(options, 'filterTable');
+  if (filterTableOption) {
+    if (typeof filterTableOption === 'string') {
+      // User provided a specific level for filtering
+      filterLevel = filterTableOption as AuditLevel;
+    } else {
+      // User provided true flag, use the audit level
+      filterLevel = auditLevel;
+    }
+  }
+
   // Get the exceptions
   const nsprc = readFile('.nsprc');
   const cmdExceptions: string[] = get(options, 'exclude', '')
@@ -53,5 +66,5 @@ export default function handleInput(
     .map((each: string) => each.trim())
     .filter((each: string) => !!each);
 
-  fn(auditCommand, auditLevel, exceptionIds, cmdModuleIgnore, cmdIncludeColumns);
+  fn(auditCommand, auditLevel, exceptionIds, cmdModuleIgnore, cmdIncludeColumns, filterLevel);
 }

--- a/src/types/general.d.ts
+++ b/src/types/general.d.ts
@@ -5,6 +5,7 @@ export interface CommandOptions {
   readonly moduleIgnore?: string;
   readonly production?: boolean;
   readonly level?: AuditLevel;
+  readonly filterTable?: string | boolean;
   readonly registry?: string;
   readonly includeColumns?: string;
 }

--- a/src/utils/vulnerability.ts
+++ b/src/utils/vulnerability.ts
@@ -115,6 +115,7 @@ export function validateV7Vulnerability(
  * @param  {Array} exceptionIds     Exception IDs (ID to be ignored)
  * @param  {Array} exceptionModules Exception modules (modules to be ignored)
  * @param  {Array} columnsToInclude List of columns to include in audit results
+ * @param  {String} filterLevel     Optional level to filter table display (if not provided, shows all vulnerabilities)
  * @return {Object}                 Processed vulnerabilities details
  */
 export function processAuditJson(
@@ -123,6 +124,7 @@ export function processAuditJson(
   exceptionIds: string[] = [],
   exceptionModules: string[] = [],
   columnsToInclude: string[] = [],
+  filterLevel?: AuditLevel,
 ): ProcessedResult {
   if (!isJsonString(jsonBuffer)) {
     return {
@@ -178,8 +180,11 @@ export function processAuditJson(
             color(value, isExcepted ? '' : 'yellow', key === 'Severity' ? getSeverityBgColor(cur.severity) : undefined),
           );
 
-        // Record this vulnerability into the report, and highlight it using yellow color if it's new
-        acc.report.push(rowData);
+        // Record this vulnerability into the report based on filter level
+        const shouldIncludeInTable = filterLevel ? mapLevelToNumber(cur.severity) >= mapLevelToNumber(filterLevel) : true;
+        if (shouldIncludeInTable) {
+          acc.report.push(rowData);
+        }
 
         acc.vulnerabilityIds.push(cur.id.toString());
         if (!acc.vulnerabilityModules.includes(cur.module_name)) {
@@ -244,8 +249,11 @@ export function processAuditJson(
             .filter(({ key }) => (columnsToInclude.length ? columnsToInclude.includes(key) : true))
             .map(({ key, value, bgColor }) => color(value, isExcepted ? '' : 'yellow', key === 'Severity' ? bgColor : undefined));
 
-          // Record this vulnerability into the report, and highlight it using yellow color if it's new
-          acc.report.push(rowData);
+          // Record this vulnerability into the report based on filter level
+          const shouldIncludeInTable = filterLevel ? mapLevelToNumber(vul.severity) >= mapLevelToNumber(filterLevel) : true;
+          if (shouldIncludeInTable) {
+            acc.report.push(rowData);
+          }
 
           acc.vulnerabilityIds.push(String(id));
           if (!acc.vulnerabilityModules.includes(moduleName)) {

--- a/test/utils/vulnerability.test.ts
+++ b/test/utils/vulnerability.test.ts
@@ -349,6 +349,38 @@ describe('Vulnerability utils', () => {
         expect(result).to.have.property('unhandledIds');
         expect(result.unhandledIds).to.have.length(1).and.to.deep.equal(['1555']);
       });
+
+      it('should be able to filter table by moderate level while keeping all vulnerability data', () => {
+        const jsonString = JSON.stringify(V6_JSON_BUFFER);
+        const auditLevel = 'info';
+        const filterLevel = 'moderate';
+        const result = processAuditJson(jsonString, auditLevel, [], [], [], filterLevel);
+
+        expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
+        expect(result).to.have.property('report').and.to.have.length(5); // Only moderate, high, critical in table
+
+        expect(result).to.have.property('unhandledIds');
+        expect(result.unhandledIds)
+          .to.have.length(11) // All vulnerabilities still count for exit code
+          .and.to.deep.equal(['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555', '1556', '1589']);
+      });
+
+      it('should be able to filter table by high level while keeping all vulnerability data', () => {
+        const jsonString = JSON.stringify(V6_JSON_BUFFER);
+        const auditLevel = 'info';
+        const filterLevel = 'high';
+        const result = processAuditJson(jsonString, auditLevel, [], [], [], filterLevel);
+
+        expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
+        expect(result).to.have.property('report').and.to.have.length(2); // Only high, critical in table
+
+        expect(result).to.have.property('unhandledIds');
+        expect(result.unhandledIds)
+          .to.have.length(11) // All vulnerabilities still count for exit code
+          .and.to.deep.equal(['975', '976', '985', '1084', '1179', '1213', '1500', '1523', '1555', '1556', '1589']);
+      });
     });
 
     describe('npm v7', () => {
@@ -474,6 +506,38 @@ describe('Vulnerability utils', () => {
 
         expect(result).to.have.property('unhandledIds');
         expect(result.unhandledIds).to.have.length(1).and.to.deep.equal(['1555']);
+      });
+
+      it('should be able to filter table by moderate level while keeping all vulnerability data', () => {
+        const jsonString = JSON.stringify(V7_JSON_BUFFER);
+        const auditLevel = 'info';
+        const filterLevel = 'moderate';
+        const result = processAuditJson(jsonString, auditLevel, [], [], [], filterLevel);
+
+        expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
+        expect(result).to.have.property('report').and.to.have.length(5); // Only moderate, high, critical in table
+
+        expect(result).to.have.property('unhandledIds');
+        expect(result.unhandledIds)
+          .to.have.length(11) // All vulnerabilities still count for exit code
+          .and.to.deep.equal(['1555', '1213', '1589', '1523', '1084', '1179', '1556', '975', '976', '985', '1500']);
+      });
+
+      it('should be able to filter table by high level while keeping all vulnerability data', () => {
+        const jsonString = JSON.stringify(V7_JSON_BUFFER);
+        const auditLevel = 'info';
+        const filterLevel = 'high';
+        const result = processAuditJson(jsonString, auditLevel, [], [], [], filterLevel);
+
+        expect(result).to.have.property('vulnerabilityIds').and.to.have.length(11);
+        expect(result).to.have.property('vulnerabilityModules').and.to.have.length(9);
+        expect(result).to.have.property('report').and.to.have.length(2); // Only high, critical in table
+
+        expect(result).to.have.property('unhandledIds');
+        expect(result.unhandledIds)
+          .to.have.length(11) // All vulnerabilities still count for exit code
+          .and.to.deep.equal(['1555', '1213', '1589', '1523', '1084', '1179', '1556', '975', '976', '985', '1500']);
       });
     });
   });


### PR DESCRIPTION
### Summary
Adds a new `--filter-table` flag that allows users to filter the vulnerability table to show only vulnerabilities at or above a specified severity level, addressing issue #64.

### Key Features
- **Backwards compatible**: Default behavior unchanged, filtering is opt-in
- **Flexible usage**: Accepts specific levels (`--filter-table high`) or boolean flag (`--filter-table`) 
- **Independent control**: Table filtering is separate from audit level exit behavior
- **Smart defaults**: Boolean flag uses the audit level as the filter level

### Usage Examples
```bash
# Filter table to show only high and critical vulnerabilities
better-npm-audit audit --filter-table high

# Filter table to match the audit level
better-npm-audit audit --level moderate --filter-table

# Different levels for exit behavior vs table display
better-npm-audit audit --level high --filter-table moderate
```

### Benefits
- **Reduces noise** in vulnerability reports while maintaining existing CI/CD behavior
- **Preserves exit codes** - audit level still controls process exit and vulnerability counting
- **Maintains compatibility** - existing workflows continue to work unchanged

### Changes
- Added `--filter-table` / `-f` command line flag
- Updated vulnerability processing to conditionally filter table rows
- Added comprehensive test coverage for new functionality
- Updated README.md with documentation and examples

**Resolves:** #64