### PR TITLE
Document available columns for --include-columns flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ better-npm-audit audit --level high --filter-table moderate
 | `--filter-table`    | `-f`  | Filter the vulnerability table to show only vulnerabilities at or above the specified level. Accepts a level (`info`, `low`, `moderate`, `high`, `critical`) or can be used as a boolean flag to filter by the audit level |
 | `--production`      | `-p`  | Skip the `devDependencies`                                                                            |
 | `--registry`        | `-r`  | The npm registry url to use                                                                           |
-| `--include-columns` | `-i`  | Columns to include in report                                                                          |
+| `--include-columns` | `-i`  | Columns to include in report. Available columns: `ID`, `Module`, `Title`, `Paths`, `Severity`, `URL`, `Ex.` (e.g. `-i Module,Title,Severity`) |
 
 <br />
 


### PR DESCRIPTION
The README's Options table now lists valid column names and format, which previously had to be read from source.